### PR TITLE
Improve type information and bad mapping detection

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     },
     "require": {
         "php": "^7.2 || ^8.0",
-        "nikic/php-parser": "^4.2.2",
+        "nikic/php-parser": "^4.7.0",
         "psr/container": "^1.0",
         "psr/log": "^1.1"
     },

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,6 +1,11 @@
 parameters:
 	ignoreErrors:
 		-
+			message: "#^Constructor of class Firehed\\\\Container\\\\Compiler\\\\ProxyValue has an unused parameter \\$interfaceName\\.$#"
+			count: 1
+			path: src/Compiler/ProxyValue.php
+
+		-
 			message: "#^Parameter \\#1 \\$exception of method PHPUnit\\\\Framework\\\\TestCase\\:\\:expectException\\(\\) expects class\\-string\\<Throwable\\>, string given\\.$#"
 			count: 2
 			path: tests/BuilderTest.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,4 +5,5 @@ includes:
 parameters:
     ignoreErrors:
         - '#^Dynamic call to static method PHPUnit\\Framework\\Assert::assert#'
+        - '#^Invalid type Psr\\Container\\ContainerExceptionInterface to throw.#'
     level: max

--- a/src/AutowireInterface.php
+++ b/src/AutowireInterface.php
@@ -5,5 +5,6 @@ namespace Firehed\Container;
 
 interface AutowireInterface
 {
+    /** @return ?class-string */
     public function getWiredClass(): ?string;
 }

--- a/src/AutowiredClass.php
+++ b/src/AutowiredClass.php
@@ -5,14 +5,16 @@ namespace Firehed\Container;
 
 class AutowiredClass implements AutowireInterface
 {
-    /** @var ?string */
+    /** @var ?class-string */
     private $class;
 
+    /** @param ?class-string $class */
     public function __construct(?string $class = null)
     {
         $this->class = $class;
     }
 
+    /** @inheritdoc */
     public function getWiredClass(): ?string
     {
         return $this->class;

--- a/src/Compiler/AutowiredValue.php
+++ b/src/Compiler/AutowiredValue.php
@@ -17,6 +17,7 @@ class AutowiredValue implements CodeGeneratorInterface
     /** @var string[] */
     private $dependencies;
 
+    /** @param class-string $classToAutowire */
     public function __construct(string $classToAutowire)
     {
         if (!class_exists($classToAutowire)) {
@@ -68,7 +69,7 @@ PHP;
         }
         if ($param->hasType()) {
             $type = $param->getType();
-            assert($type !== null);
+            assert($type instanceof ReflectionNamedType);
             return !$type->isBuiltin();
         }
         return false;

--- a/src/Compiler/AutowiredValue.php
+++ b/src/Compiler/AutowiredValue.php
@@ -20,9 +20,7 @@ class AutowiredValue implements CodeGeneratorInterface
     /** @param class-string $classToAutowire */
     public function __construct(string $classToAutowire)
     {
-        if (!class_exists($classToAutowire)) {
-            // throw
-        }
+        assert(class_exists($classToAutowire));
         $this->class = $classToAutowire;
     }
 

--- a/src/Compiler/ProxyValue.php
+++ b/src/Compiler/ProxyValue.php
@@ -3,16 +3,22 @@ declare(strict_types=1);
 
 namespace Firehed\Container\Compiler;
 
+/**
+ * This maps an interface to a class-string implementation
+ */
 class ProxyValue implements CodeGeneratorInterface
 {
-    /** @var string FQCN */
+    /** @var class-string */
     private $class;
 
-    public function __construct(string $classToAutowire)
+    /**
+     * @param class-string $interfaceName
+     * @param class-string $classToAutowire
+     */
+    public function __construct(string $interfaceName, string $classToAutowire)
     {
-        if (!class_exists($classToAutowire)) {
-            // throw
-        }
+        assert(class_exists($classToAutowire));
+        // TODO: Warn if class doesn't implement interface?
         $this->class = $classToAutowire;
     }
 

--- a/src/DevContainer.php
+++ b/src/DevContainer.php
@@ -59,7 +59,7 @@ class DevContainer implements Container\ContainerInterface
 
         if ($value instanceof Closure) {
             $rebound = $value->bindTo(null);
-            assert($rebound !== false);
+            assert($rebound !== null);
             $evaluated = $rebound($this);
             $this->evaluated[$id] = $evaluated;
 

--- a/src/DevContainer.php
+++ b/src/DevContainer.php
@@ -58,8 +58,9 @@ class DevContainer implements Container\ContainerInterface
         }
 
         if ($value instanceof Closure) {
-            $value = $value->bindTo(null);
-            $evaluated = $value($this);
+            $rebound = $value->bindTo(null);
+            assert($rebound !== false);
+            $evaluated = $rebound($this);
             $this->evaluated[$id] = $evaluated;
 
             return $evaluated;
@@ -146,10 +147,10 @@ class DevContainer implements Container\ContainerInterface
                 }
                 $type = $param->getType();
                 assert($type !== null);
+                assert($type instanceof ReflectionNamedType);
                 if ($type->isBuiltin()) {
                     throw new Exceptions\UntypedValue($param->getName(), $id);
                 }
-                assert($type instanceof ReflectionNamedType);
                 $name = $type->getName();
                 if (!$this->has($name)) {
                     throw new Exceptions\NotFound($param->getName());

--- a/src/DevContainer.php
+++ b/src/DevContainer.php
@@ -119,7 +119,7 @@ class DevContainer implements Container\ContainerInterface
     private function autowire(string $id): Closure
     {
         if (!class_exists($id)) {
-            throw new \Exception('not a class');
+            throw new Exceptions\AmbiguousMapping($id);
         }
         $rc = new ReflectionClass($id);
 

--- a/src/Exceptions/AmbiguousMapping.php
+++ b/src/Exceptions/AmbiguousMapping.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+namespace Firehed\Container\Exceptions;
+
+use Exception;
+use Psr\Container\ContainerExceptionInterface;
+
+class AmbiguousMapping extends Exception implements ContainerExceptionInterface
+{
+    public function __construct(string $key)
+    {
+        parent::__construct(sprintf(
+            'Cannot determine target for key `%s`',
+            $key
+        ));
+    }
+}

--- a/src/Exceptions/InvalidClassMapping.php
+++ b/src/Exceptions/InvalidClassMapping.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace Firehed\Container\Exceptions;
+
+use Exception;
+use Psr\Container\ContainerExceptionInterface;
+
+class InvalidClassMapping extends Exception implements ContainerExceptionInterface
+{
+    public function __construct(string $interfaceName, string $nonClassName)
+    {
+        parent::__construct(sprintf(
+            'Interface `%s` cannot be mapped to non-class `%s`',
+            $interfaceName,
+            $nonClassName
+        ));
+    }
+}

--- a/src/functions.php
+++ b/src/functions.php
@@ -4,6 +4,7 @@ namespace Firehed\Container;
 
 use Closure;
 
+/** @param ?class-string $class */
 function autowire(?string $class = null): AutowireInterface
 {
     return new AutowiredClass($class);

--- a/tests/BuilderTest.php
+++ b/tests/BuilderTest.php
@@ -7,6 +7,7 @@ namespace Firehed\Container;
  * @coversDefaultClass Firehed\Container\Builder
  * @covers ::<protected>
  * @covers ::<private>
+ * @covers Firehed\Container\DevContainer
  */
 class BuilderTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/CompilerTest.php
+++ b/tests/CompilerTest.php
@@ -9,6 +9,7 @@ use Psr\Log\AbstractLogger;
  * @coversDefaultClass Firehed\Container\Compiler
  * @covers ::<protected>
  * @covers ::<private>
+ * @covers Firehed\Container\CompiledContainer
  */
 class CompilerTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/ErrorDefinitions/AmbiguousInterfaceExplicit.php
+++ b/tests/ErrorDefinitions/AmbiguousInterfaceExplicit.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Firehed\Container\Fixtures;
+
+use function Firehed\Container\autowire;
+
+return [
+    // Explicit interface mapping is ambiguous
+    SessionHandlerInterface::class => autowire(),
+];

--- a/tests/ErrorDefinitions/AmbiguousInterfaceImplicit.php
+++ b/tests/ErrorDefinitions/AmbiguousInterfaceImplicit.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Firehed\Container\Fixtures;
+
+return [
+    // Implicit interface mapping is ambiguous
+    SessionHandlerInterface::class,
+];

--- a/tests/ErrorDefinitions/InterfaceFactory.php
+++ b/tests/ErrorDefinitions/InterfaceFactory.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Firehed\Container\Fixtures;
+
+use function Firehed\Container\factory;
+
+return [
+    // Interface to factory cannot be resolved
+    SessionHandlerInterface::class => factory(),
+];

--- a/tests/ErrorDefinitions/InterfaceToNonClass.php
+++ b/tests/ErrorDefinitions/InterfaceToNonClass.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Firehed\Container\Fixtures;
+
+return [
+    // It's assumed that any array key that's an interface name which doesn't
+    // map to a factory or closure is an error.
+    SessionHandlerInterface::class => 'Not a class',
+];

--- a/tests/ErrorDefinitions/StringFactory.php
+++ b/tests/ErrorDefinitions/StringFactory.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Firehed\Container\Fixtures;
+
+use function Firehed\Container\factory;
+
+return [
+    // Non-class to factory (without body) cannot be resolved
+    'hello' => factory(),
+];

--- a/tests/ErrorDefinitionsTestTrait.php
+++ b/tests/ErrorDefinitionsTestTrait.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace Firehed\Container;
 
+use SessionHandlerInterface;
+
 trait ErrorDefinitionsTestTrait
 {
     abstract protected function getBuilder(): BuilderInterface;
@@ -40,7 +42,7 @@ trait ErrorDefinitionsTestTrait
         $builder->addFile(__DIR__ . '/ErrorDefinitions/AmbiguousInterfaceImplicit.php');
         $this->expectException(Exceptions\AmbiguousMapping::class);
         $c = $builder->build();
-        $c->get(Fixtures\SessionHandlerInterface::class);
+        $c->get(SessionHandlerInterface::class);
     }
 
     public function testExplicitInterfaceAutowire(): void
@@ -49,7 +51,7 @@ trait ErrorDefinitionsTestTrait
         $builder->addFile(__DIR__ . '/ErrorDefinitions/AmbiguousInterfaceExplicit.php');
         $this->expectException(Exceptions\AmbiguousMapping::class);
         $c = $builder->build();
-        $c->get(Fixtures\SessionHandlerInterface::class);
+        $c->get(SessionHandlerInterface::class);
     }
 
     public function testInterfaceToNonClass(): void
@@ -58,7 +60,7 @@ trait ErrorDefinitionsTestTrait
         $builder->addFile(__DIR__ . '/ErrorDefinitions/InterfaceToNonClass.php');
         $this->expectException(Exceptions\InvalidClassMapping::class);
         $c = $builder->build();
-        $c->get(Fixtures\SessionHandlerInterface::class);
+        $c->get(SessionHandlerInterface::class);
     }
 
     public function testInterfaceFactory(): void
@@ -67,14 +69,15 @@ trait ErrorDefinitionsTestTrait
         $builder->addFile(__DIR__ . '/ErrorDefinitions/InterfaceFactory.php');
         $this->expectException(Exceptions\AmbiguousMapping::class);
         $c = $builder->build();
-        $c->get(Fixtures\SessionHandlerInterface::class);
+        $c->get(SessionHandlerInterface::class);
     }
+
     public function testStringFactory(): void
     {
         $builder = $this->getBuilder();
         $builder->addFile(__DIR__ . '/ErrorDefinitions/StringFactory.php');
         $this->expectException(Exceptions\AmbiguousMapping::class);
         $c = $builder->build();
-        $c->get(Fixtures\SessionHandlerInterface::class);
+        $c->get('hello');
     }
 }

--- a/tests/ErrorDefinitionsTestTrait.php
+++ b/tests/ErrorDefinitionsTestTrait.php
@@ -33,4 +33,48 @@ trait ErrorDefinitionsTestTrait
         $c = $builder->build();
         $c->get(Fixtures\SessionHandler::class);
     }
+
+    public function testImplicitInterfaceAutowire(): void
+    {
+        $builder = $this->getBuilder();
+        $builder->addFile(__DIR__ . '/ErrorDefinitions/AmbiguousInterfaceImplicit.php');
+        $this->expectException(Exceptions\AmbiguousMapping::class);
+        $c = $builder->build();
+        $c->get(Fixtures\SessionHandlerInterface::class);
+    }
+
+    public function testExplicitInterfaceAutowire(): void
+    {
+        $builder = $this->getBuilder();
+        $builder->addFile(__DIR__ . '/ErrorDefinitions/AmbiguousInterfaceExplicit.php');
+        $this->expectException(Exceptions\AmbiguousMapping::class);
+        $c = $builder->build();
+        $c->get(Fixtures\SessionHandlerInterface::class);
+    }
+
+    public function testInterfaceToNonClass(): void
+    {
+        $builder = $this->getBuilder();
+        $builder->addFile(__DIR__ . '/ErrorDefinitions/InterfaceToNonClass.php');
+        $this->expectException(Exceptions\InvalidClassMapping::class);
+        $c = $builder->build();
+        $c->get(Fixtures\SessionHandlerInterface::class);
+    }
+
+    public function testInterfaceFactory(): void
+    {
+        $builder = $this->getBuilder();
+        $builder->addFile(__DIR__ . '/ErrorDefinitions/InterfaceFactory.php');
+        $this->expectException(Exceptions\AmbiguousMapping::class);
+        $c = $builder->build();
+        $c->get(Fixtures\SessionHandlerInterface::class);
+    }
+    public function testStringFactory(): void
+    {
+        $builder = $this->getBuilder();
+        $builder->addFile(__DIR__ . '/ErrorDefinitions/StringFactory.php');
+        $this->expectException(Exceptions\AmbiguousMapping::class);
+        $c = $builder->build();
+        $c->get(Fixtures\SessionHandlerInterface::class);
+    }
 }


### PR DESCRIPTION
This accomplishes a few things:

- Fixes minor PHPStan issues (mostly around `class-string`) revealed in newer versions
- Improves build-time type checking, particularly around interface-to-implementation mappings
- Adds numerous test cases for bad definitions