### PR TITLE
Don't use old coversDefaultClass-style coverage annotations

### DIFF
--- a/tests/BuilderTest.php
+++ b/tests/BuilderTest.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 namespace Firehed\Container;
 
 /**
- * @coversDefaultClass Firehed\Container\Builder
- * @covers ::<protected>
- * @covers ::<private>
+ * @covers Firehed\Container\Builder
  * @covers Firehed\Container\DevContainer
  */
 class BuilderTest extends \PHPUnit\Framework\TestCase

--- a/tests/CompilerTest.php
+++ b/tests/CompilerTest.php
@@ -6,9 +6,7 @@ namespace Firehed\Container;
 use Psr\Log\AbstractLogger;
 
 /**
- * @coversDefaultClass Firehed\Container\Compiler
- * @covers ::<protected>
- * @covers ::<private>
+ * @covers Firehed\Container\Compiler
  * @covers Firehed\Container\CompiledContainer
  */
 class CompilerTest extends \PHPUnit\Framework\TestCase


### PR DESCRIPTION
This stops using functionality that will be removed in PHPUnit 10.