### PR TITLE
Update return type for session handler interface in tests

### DIFF
--- a/tests/Fixtures/SessionHandler.php
+++ b/tests/Fixtures/SessionHandler.php
@@ -38,10 +38,11 @@ class SessionHandler implements SessionIdInterface, SessionHandlerInterface
 
     /**
      * @param int $maxlifetime
+     * @return int|false
      */
-    public function gc($maxlifetime): bool
+    public function gc($maxlifetime)
     {
-        return true;
+        return 0;
     }
 
     /**


### PR DESCRIPTION
Addresses an issue revealed by static analysis. Doesn't actually break anything, just part of the test suite.