### PR TITLE
Improve type safety of containers w/ tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,34 @@ This is intended to reduce unpredictable behavior of services in concurrent envi
 - Annotations are not supported.
   In future versions, `@param` annotations _may_ be supported; `@Inject` will never be.
 
+### Design Opinions
+
+Like many autowiring DI containers, this has some opinionated design decisions.
+You may or may not agree, but it's important to document them to help you make an informed choice about whether this library is right for you.
+
+- This is based around having a distinct build/compile stage for your application's deployment process.
+  Implicit autowiring will NOT occur in the production-ready compiled container, which yields performance improvements.
+  Add the autowired class name to any definition file to explicitly wire it (`Foo::class,` is sufficient, see "Automatic autowiring" below).
+
+- Any `$id` that's a valid class string should return an instance of that class (or interface, enum).
+  As of 0.6, this is reflected in the provided type information: `->get($id)` has Generic information for PHPStan where if a `class-string` is detected, get returns that class.
+  This is not (currently) enforced at runtime, but be warned that e.g. `$container->get(LoggerInterface::class);` will be indicated as being a `LoggerInteface` to static analysis tools, and if the definition doesn't do that, you may get conflicts.
+
+- All files should always be included.
+  Do NOT skip files based on the environment.
+  Instead, definitions should be conditional.
+  Example:
+  ```php
+  <?php
+
+  return [
+      MyInterface::class => function ($c) {
+        return $c->get('use_mocks')
+            ? $c->get(MyImplementationMock::class)
+            : $c->get(MyImplementationReal::class);
+      },
+  ];
+  ```
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ You may or may not agree, but it's important to document them to help you make a
 
   return [
       MyInterface::class => function ($c) {
-        return $c->get('use_mocks')
-            ? $c->get(MyImplementationMock::class)
-            : $c->get(MyImplementationReal::class);
+          return $c->get('use_mocks')
+              ? $c->get(MyImplementationMock::class)
+              : $c->get(MyImplementationReal::class);
       },
   ];
   ```

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace Firehed\Container;
 
-use Psr\Container\ContainerInterface;
 use Psr\Container\ContainerExceptionInterface;
 use UnexpectedValueException;
 
@@ -64,7 +63,7 @@ class Builder implements BuilderInterface
         return $output;
     }
 
-    public function build(): ContainerInterface
+    public function build(): TypedContainerInterface
     {
         if ($this->errors !== []) {
             throw $this->errors[0];

--- a/src/BuilderInterface.php
+++ b/src/BuilderInterface.php
@@ -3,11 +3,9 @@ declare(strict_types=1);
 
 namespace Firehed\Container;
 
-use Psr\Container\ContainerInterface;
-
 interface BuilderInterface
 {
     public function addFile(string $file): void;
 
-    public function build(): ContainerInterface;
+    public function build(): TypedContainerInterface;
 }

--- a/src/CompiledContainer.php
+++ b/src/CompiledContainer.php
@@ -3,9 +3,7 @@ declare(strict_types=1);
 
 namespace Firehed\Container;
 
-use Psr\Container\ContainerInterface;
-
-abstract class CompiledContainer implements ContainerInterface
+abstract class CompiledContainer implements TypedContainerInterface
 {
     /**
      * Tracks what $id keys correspond to factory definitions and must not be
@@ -26,18 +24,11 @@ abstract class CompiledContainer implements ContainerInterface
      */
     protected $mappings = [];
 
-    /**
-     * @param string $id
-     */
     public function has($id): bool
     {
         return array_key_exists($id, $this->mappings);
     }
 
-    /**
-     * @param string $id
-     * @return mixed
-     */
     public function get($id)
     {
         if (!$this->has($id)) {

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -7,7 +7,6 @@ use Closure;
 use PhpParser\ParserFactory;
 use PhpParser\PrettyPrinter\Standard;
 use Psr\Container\ContainerExceptionInterface;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use UnexpectedValueException;
@@ -28,7 +27,7 @@ use function realpath;
 
 class Compiler implements BuilderInterface
 {
-    /** @var class-string<ContainerInterface> */
+    /** @var class-string<TypedContainerInterface> */
     private $className;
 
     /** @var Compiler\CodeGeneratorInterface[] */
@@ -165,7 +164,7 @@ class Compiler implements BuilderInterface
         }
     }
 
-    public function build(): ContainerInterface
+    public function build(): TypedContainerInterface
     {
         $this->compile();
         require_once $this->path;

--- a/src/DevContainer.php
+++ b/src/DevContainer.php
@@ -5,11 +5,10 @@ namespace Firehed\Container;
 
 use Closure;
 use Exception;
-use Psr\Container;
 use ReflectionClass;
 use ReflectionNamedType;
 
-class DevContainer implements Container\ContainerInterface
+class DevContainer implements TypedContainerInterface
 {
     /** @var mixed[] */
     private $definitions;
@@ -23,20 +22,11 @@ class DevContainer implements Container\ContainerInterface
         $this->definitions = $definitions;
     }
 
-    /**
-     * Docblock types for interface adherence
-     * @param string $id
-     */
     public function has($id): bool
     {
         return array_key_exists($id, $this->definitions);
     }
 
-    /**
-     * Docblock types for interface adherence
-     * @param string $id
-     * @return mixed
-     */
     public function get($id)
     {
         if (array_key_exists($id, $this->evaluated)) {

--- a/src/TypedContainerInterface.php
+++ b/src/TypedContainerInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\Container;
+
+use Psr\Container\ContainerInterface;
+
+interface TypedContainerInterface extends ContainerInterface
+{
+    /**
+     * @template T
+     * @param string $id
+     * @return ($id is class-string<T> ? T : mixed)
+     */
+    public function get($id);
+}


### PR DESCRIPTION
Previously, `$container->get(SomeClass::class)` would typehint to `mixed`. Since this library is built with the opinion that if get()'s $id is a class name then that class should be returned, this change adds that to the output: it leverages [conditional return types](https://phpstan.org/writing-php-code/phpdoc-types#conditional-return-types) to detect a `class-string` and indicate that class is returned. Other values will continue to be mixed for now.