### PR TITLE
Ensure config entries with match statements can compile

### DIFF
--- a/src/Compiler/ParserLoader.php
+++ b/src/Compiler/ParserLoader.php
@@ -17,7 +17,7 @@ class ParserLoader
         $factory = new ParserFactory();
         if (method_exists($factory, 'createForVersion')) { // @phpstan-ignore-line
             // v5
-            return $factory->createForVersion(PhpVersion::fromString('7.0'));
+            return $factory->createForVersion(PhpVersion::fromString('8.1'));
         } else {
             // v4
             assert(method_exists($factory, 'create'));

--- a/tests/ContainerBuilderTestTrait.php
+++ b/tests/ContainerBuilderTestTrait.php
@@ -297,9 +297,9 @@ trait ContainerBuilderTestTrait
 
     public function testClosureUsingMatch(): void
     {
-        $c = $this->getContainer();
-        $r = $c->get('somethingWithMatch');
-        var_dump($r);
+        $container = $this->getContainer();
+        $value = $container->get('somethingWithMatch');
+        self::assertIsString($value);
     }
 
     /**

--- a/tests/ContainerBuilderTestTrait.php
+++ b/tests/ContainerBuilderTestTrait.php
@@ -295,6 +295,13 @@ trait ContainerBuilderTestTrait
         $container->get('key_that_does_not_exist');
     }
 
+    public function testClosureUsingMatch(): void
+    {
+        $c = $this->getContainer();
+        $r = $c->get('somethingWithMatch');
+        var_dump($r);
+    }
+
     /**
      * @covers \Firehed\Container\Compiler\ClosureValue
      * @covers \Firehed\Container\Compiler\ClosureVisitor

--- a/tests/ValidDefinitions/Closures.php
+++ b/tests/ValidDefinitions/Closures.php
@@ -29,4 +29,10 @@ return [
     'somethingUsingAliasedName' => function ($c) {
         return $c->get(EI::class);
     },
+
+    'somethingWithMatch' => fn ($c) => match ($c->get('string_literal')) {
+        'UnitTest' => 'foobar',
+        'other' => 'bar',
+        default => 'baz',
+    },
 ];


### PR DESCRIPTION
The parser version needed to be updated to reflect the availability of match statements (which is technically 8.0, but this might as well match the library's own minimum PHP version)

Prior to this change, the compiler would crash with `PhpParser\Error: Syntax error, unexpected T_DOUBLE_ARROW` (and, presumably, interpret `match()` as a function call rather than language construct).