### PR TITLE
More typed value tooling

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -12,15 +12,3 @@ parameters:
 			count: 1
 			path: src/Compiler/ParserLoader.php
 
-		-
-			message: '#^Binary operation "\." between ''https\://'' and mixed results in an error\.$#'
-			identifier: binaryOp.invalid
-			count: 1
-			path: tests/ErrorDefinitions/ErrorException.php
-
-		-
-			message: '#^Parameter \#1 \$value of static method Firehed\\Container\\Fixtures\\Environment\:\:from\(\) expects int\|string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: tests/ValidDefinitions/Enums.php
-

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -10,3 +10,4 @@ parameters:
     paths:
         - src
         - tests
+    treatPhpDocTypesAsCertain: false

--- a/src/CompiledContainer.php
+++ b/src/CompiledContainer.php
@@ -8,6 +8,8 @@ use Psr\Container\ContainerExceptionInterface;
 
 abstract class CompiledContainer implements TypedContainerInterface
 {
+    use TypedContainerTrait;
+
     /**
      * Tracks what $id keys correspond to factory definitions and must not be
      * cached

--- a/src/DevContainer.php
+++ b/src/DevContainer.php
@@ -12,6 +12,8 @@ use Throwable;
 
 class DevContainer implements TypedContainerInterface
 {
+    use TypedContainerTrait;
+
     /** @var mixed[] */
     private $evaluated = [];
 

--- a/src/Exceptions/IncorrectlyTypedValue.php
+++ b/src/Exceptions/IncorrectlyTypedValue.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\Container\Exceptions;
+
+use Exception;
+use Psr\Container\ContainerExceptionInterface;
+
+class IncorrectlyTypedValue extends Exception implements ContainerExceptionInterface
+{
+    public function __construct(
+        string $id,
+        string $expectedType,
+        string $actualType,
+    ) {
+        parent::__construct(sprintf(
+            'Could not retrieve `%s` as %s, value is %s',
+            $id,
+            $expectedType,
+            $actualType,
+        ));
+    }
+}

--- a/src/TypedContainerInterface.php
+++ b/src/TypedContainerInterface.php
@@ -14,4 +14,12 @@ interface TypedContainerInterface extends ContainerInterface
      * @return ($id is class-string<T> ? T : mixed)
      */
     public function get($id);
+
+    public function getBool(string $id): bool;
+
+    public function getFloat(string $id): float;
+
+    public function getInt(string $id): int;
+
+    public function getString(string $id): string;
 }

--- a/src/TypedContainerTrait.php
+++ b/src/TypedContainerTrait.php
@@ -6,6 +6,11 @@ namespace Firehed\Container;
 
 use Firehed\Container\Exceptions\IncorrectlyTypedValue;
 
+use function is_bool;
+use function is_float;
+use function is_int;
+use function is_string;
+
 trait TypedContainerTrait
 {
     public function getBool(string $id): bool

--- a/src/TypedContainerTrait.php
+++ b/src/TypedContainerTrait.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\Container;
+
+trait TypedContainerTrait
+{
+    public function getBool(string $id): bool
+    {
+        return $this->get($id);
+    }
+
+    public function getFloat(string $id): float
+    {
+        return $this->get($id);
+    }
+
+    public function getInt(string $id): int
+    {
+        return $this->get($id);
+    }
+
+    public function getString(string $id): string
+    {
+        return $this->get($id);
+    }
+}

--- a/src/TypedContainerTrait.php
+++ b/src/TypedContainerTrait.php
@@ -4,25 +4,43 @@ declare(strict_types=1);
 
 namespace Firehed\Container;
 
+use Firehed\Container\Exceptions\IncorrectlyTypedValue;
+
 trait TypedContainerTrait
 {
     public function getBool(string $id): bool
     {
-        return $this->get($id);
+        $value = $this->get($id);
+        if (is_bool($value)) {
+            return $value;
+        }
+        throw new IncorrectlyTypedValue($id, 'bool', gettype($value));
     }
 
     public function getFloat(string $id): float
     {
-        return $this->get($id);
+        $value = $this->get($id);
+        if (is_float($value)) {
+            return $value;
+        }
+        throw new IncorrectlyTypedValue($id, 'float', gettype($value));
     }
 
     public function getInt(string $id): int
     {
-        return $this->get($id);
+        $value = $this->get($id);
+        if (is_int($value)) {
+            return $value;
+        }
+        throw new IncorrectlyTypedValue($id, 'int', gettype($value));
     }
 
     public function getString(string $id): string
     {
-        return $this->get($id);
+        $value = $this->get($id);
+        if (is_string($value)) {
+            return $value;
+        }
+        throw new IncorrectlyTypedValue($id, 'string', gettype($value));
     }
 }

--- a/tests/ContainerBuilderTestTrait.php
+++ b/tests/ContainerBuilderTestTrait.php
@@ -6,6 +6,7 @@ namespace Firehed\Container;
 use DateTime;
 use DateTimeImmutable;
 use DateTimeInterface;
+use Firehed\Container\Exceptions\IncorrectlyTypedValue;
 use Psr\Container\ContainerInterface;
 use Psr\Container\NotFoundExceptionInterface;
 use SessionHandlerInterface;
@@ -261,21 +262,25 @@ trait ContainerBuilderTestTrait
 
     public function testGetBoolErrors(): void
     {
+        self::expectException(IncorrectlyTypedValue::class);
         $this->getContainer()->getBool('int_literal');
     }
 
     public function testGetFloatErrors(): void
     {
+        self::expectException(IncorrectlyTypedValue::class);
         $this->getContainer()->getFloat('string_literal');
     }
 
     public function testGetIntErrors(): void
     {
+        self::expectException(IncorrectlyTypedValue::class);
         $this->getContainer()->getInt('string_literal');
     }
 
     public function testGetStringErrors(): void
     {
+        self::expectException(IncorrectlyTypedValue::class);
         $this->getContainer()->getString('int_literal');
     }
 

--- a/tests/ContainerBuilderTestTrait.php
+++ b/tests/ContainerBuilderTestTrait.php
@@ -249,6 +249,36 @@ trait ContainerBuilderTestTrait
         $this->assertSame($expectedValue, $value, 'get should return the value');
     }
 
+    public function testTypedScalarLiteralSuccesses(): void
+    {
+        $c = $this->getContainer();
+        // Success paths
+        $this->assertSame('UnitTest', $c->getString('string_literal'));
+        $this->assertSame(42, $c->getInt('int_literal'));
+        $this->assertSame(123.45, $c->getFloat('float_literal'));
+        $this->assertSame(true, $c->getBool('bool_literal'));
+    }
+
+    public function testGetBoolErrors(): void
+    {
+        $this->getContainer()->getBool('int_literal');
+    }
+
+    public function testGetFloatErrors(): void
+    {
+        $this->getContainer()->getFloat('string_literal');
+    }
+
+    public function testGetIntErrors(): void
+    {
+        $this->getContainer()->getInt('string_literal');
+    }
+
+    public function testGetStringErrors(): void
+    {
+        $this->getContainer()->getString('int_literal');
+    }
+
     /**
      * DefaultScalarParam::class => autowire()
      */

--- a/tests/ContainerBuilderTestTrait.php
+++ b/tests/ContainerBuilderTestTrait.php
@@ -21,7 +21,7 @@ trait ContainerBuilderTestTrait
     use EnvironmentDefinitionsTestTrait;
     use ErrorDefinitionsTestTrait;
 
-    public function getContainer(): ContainerInterface
+    public function getContainer(): TypedContainerInterface
     {
         $builder = $this->getBuilder();
         foreach (self::getDefinitionFiles() as $file) {

--- a/tests/ErrorDefinitions/ErrorException.php
+++ b/tests/ErrorDefinitions/ErrorException.php
@@ -23,7 +23,7 @@ return [
     },
 
     'api_url' => function (TypedContainerInterface $c) {
-        return 'https://' . $c->get('api_host');
+        return 'https://' . $c->getString('api_host');
     },
 
     'api_service' => function (TypedContainerInterface $c) {

--- a/tests/ValidDefinitions/Enums.php
+++ b/tests/ValidDefinitions/Enums.php
@@ -11,7 +11,7 @@ return [
     'enum_env' => 'testing',
 
     // Dynamic value
-    Environment::class => fn (TypedContainerInterface $c) => Environment::from($c->get('enum_env')),
+    Environment::class => fn (TypedContainerInterface $c) => Environment::from($c->getString('enum_env')),
 
     // Hard-coded value
     'enum_hardcoded' => Environment::STAGING,


### PR DESCRIPTION
This adds typed accessors to the TypedContainerInterface that the library returns. Use of this allows tighter checks within config definitions, which is especially useful when running static analysis tools on them.

I've left out nullables and arrays for now but they may get added in the future.