### PR TITLE
Explicitly test behavior of 'set but empty'

### DIFF
--- a/tests/EnvironmentDefinitionsTestTrait.php
+++ b/tests/EnvironmentDefinitionsTestTrait.php
@@ -78,6 +78,13 @@ trait EnvironmentDefinitionsTestTrait
         $this->assertSame($expected, $container->get($containerKey));
     }
 
+    public function testEmptyValueBehavior(): void
+    {
+        putenv(self::$prefix . 'EMPTY=');
+        $container = $this->getContainer();
+        $this->assertSame('', $container->get('env_empty'));
+    }
+
     /** @return string[][] */
     public static function envVarsThatAreSet(): array
     {

--- a/tests/ValidDefinitions/Environment.php
+++ b/tests/ValidDefinitions/Environment.php
@@ -20,6 +20,9 @@ return [
     'env_not_set_with_default' => env('CONTAINER_UNITTEST_NOT_SET', 'default'),
     'env_not_set_with_null_default' => env('CONTAINER_UNITTEST_NOT_SET', null),
 
+    // Set but empty
+    'env_empty' => env($prefix . 'EMPTY'),
+
     // Casting: boolean
     'env_asbool_one' => env($prefix . 'ONE')->asBool(),
     'env_asbool_true' => env($prefix . 'TRUE')->asBool(),


### PR DESCRIPTION
When reading env vars that are an empty string, test to make sure they're handled correctly. They already are, but this helps cover some edge cases in #61.