### PR TITLE
Fix README inconsistencies

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -57,3 +57,13 @@ jobs:
 
       - name: Run validate
         run: composer validate
+
+  typos:
+    name: Spell check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+
+      - name: Check spelling
+        uses: crate-ci/typos@v1

--- a/README.md
+++ b/README.md
@@ -218,9 +218,12 @@ If a default value is not provided and no value is in the environment, an attemp
 <?php
 return [
     'ENV_VAR_1' => function () {
-        $value = getenv('ENV_VAR_1');
-        if ($value === false) {
+        if (!array_key_exists('ENV_VAR_1', $_ENV)) {
             throw new Firehed\Container\Exceptions\EnvironmentVariableNotSet('ENV_VAR_1');
+        }
+        $value = $_ENV['ENV_VAR_1'];
+        if (!is_string($value)) {
+            throw new TypeError('$_ENV contained a non-string value for key ENV_VAR_1');
         }
         // For cast values, casting occurs here and can produce additional errors.
         return $value;

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ All values, except for those defined through `factory()`, will be memoized.
 Functionally, this results in a singleton for object types managed by the container.
 
 Want more control over config file inclusion?
-See `Usage` below.
+See `Manual Setup` below.
 
 # Documentation and Detailed Examples
 
@@ -245,7 +245,7 @@ To use this, the following methods exist:
 - `asFloat`
 - `asEnum`
 
-These are roughly equivalent to e.g. `(int) getenv('SOME_ENV_VAR')`, with the exception that `asBool` will only allow values `0`, `1`, `"true"`, and `"false"` (case-insensitively).
+These are roughly equivalent to e.g. `(int) getenv('SOME_ENV_VAR')`, with the exception that `asBool` will only allow values `0`, `1`, `"true"`, `"false"`, and `""` (empty string, treated as false), case-insensitively.
 
 `asEnum` takes a class-string to a **string-backed** enum that you have defined, and will use `::from($envValue)` to hydrate from the environment value.
 This does not attempt to locally normalize values, so the envvar value MUST match the backing value exactly.

--- a/README.md
+++ b/README.md
@@ -458,7 +458,7 @@ return [
 ### Factories
 Use the `Firehed\Container\factory` function to return a new copy of the class or value every time it is accessed through `get()`.
 
-If a paramater is not provided to the definition, the key will be used to autowire a definition.
+If a parameter is not provided to the definition, the key will be used to autowire a definition.
 If a closure is provided, that closure will be executed instead.
 
 ```php
@@ -504,7 +504,7 @@ In the majority case no handling should be needed (errors indicate either a conf
 
 The primary motivation for creating this was to have a container implementation that's optimized for containerized deployment in a long-running process (like ReactPHP and PHP-PM).
 
-The usage and API is is highly inspired by PHP-DI, but adds functionality to support factories at definition-time (rather than exclusively at access-time with `make`).
+The usage and API is highly inspired by PHP-DI, but adds functionality to support factories at definition-time (rather than exclusively at access-time with `make`).
 This is intended to reduce unpredictable behavior of services in concurrent environments while strictly adhering to the PSR container specification.
 
 ### Differences from PHP-DI
@@ -532,11 +532,11 @@ You may or may not agree, but it's important to document them to help you make a
 
 - This is based around having a distinct build/compile stage for your application's deployment process.
   Implicit autowiring will NOT occur in the production-ready compiled container, which yields performance improvements.
-  Add the autowired class name to any definition file to explicitly wire it (`Foo::class,` is sufficient, see "Automatic autowiring" below).
+  Add the autowired class name to any definition file to explicitly wire it (`Foo::class,` is sufficient, see "Class Autowiring" above).
 
 - Any `$id` that's a valid class string should return an instance of that class (or interface, enum).
   As of 0.6, this is reflected in the provided type information: `->get($id)` has Generic information for PHPStan where if a `class-string` is detected, get returns that class.
-  This is not (currently) enforced at runtime, but be warned that e.g. `$container->get(LoggerInterface::class);` will be indicated as being a `LoggerInteface` to static analysis tools, and if the definition doesn't do that, you may get conflicts.
+  This is not (currently) enforced at runtime, but be warned that e.g. `$container->get(LoggerInterface::class);` will be indicated as being a `LoggerInterface` to static analysis tools, and if the definition doesn't do that, you may get conflicts.
 
 - All files should always be included.
   Do NOT skip files based on the environment.

--- a/README.md
+++ b/README.md
@@ -482,7 +482,7 @@ assert($dt1 !== $dt2, 'Factories return a new instance on each get() call');
 ```
 
 ### Type-safe values
-In addition to inferring class types, `TypedContainerInterface`, it adds type-safe accessors for scalar values: `getBool($id)`, `getFloat($id)`, `getInt($id)`, and `getString($id)`.
+`TypedContainerInterface` also adds type-safe accessors for scalar values: `getBool($id)`, `getFloat($id)`, `getInt($id)`, and `getString($id)`.
 
 These are primarily intended to add type safety to definitions which can be verified through static analysis (e.g. PHPStan and Psalm), but can be used in whatever way you see fit.
 Doing so outside of definitions can decrease code portability.

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Any other value will run the compilation process, writing the output to `AutoDet
 You may change the output directory by changing that variable (be mindful of `getcwd()`!); the default writes into Composer's `vendor` directory since it's commonly `gitignore`d.
 
 > [!NOTE]
-> As the API implies, this returns a singleton instance of the conatiner.
+> As the API implies, this returns a singleton instance of the container.
 >
 > This works well for most modern applications, as well as for transitioning older applications using a `$config = require 'config.php';` approach.
 > 
@@ -264,7 +264,7 @@ return [
 
 ### Class Autowiring
 
-One of the primary mechnaics of this library is class autowiring.
+One of the primary mechanics of this library is class autowiring.
 
 Autowiring allows the container to determine the dependencies of a class (using reflection) and automatically provide configured values when accessed.
 This drastically reduces the amount of config definition code, along with reduced config churn as definitions change over time.
@@ -327,7 +327,7 @@ The topmost example is recommended for configuring any class that can be autowir
 > [!WARNING]
 > Dependency autowiring requires use of fully-qualified class names (FQCNs) as keys for object types (classes, interfaces, enums).
 > 
-> While you _may_ add additional aliases, you _must_ add defintions with FQCNs for autowiring to recognize that dependencies are available.
+> While you _may_ add additional aliases, you _must_ add definitions with FQCNs for autowiring to recognize that dependencies are available.
 >
 > e.g.
 > ```php
@@ -418,7 +418,7 @@ This is because the compiler cannot create an actual object instance, and thus w
 ### Closures
 
 If a closure is provided as a value, that closure will be executed when `get()` is called and the value it returns will be returned.
-This is how the above defintions work.
+This is how the above definitions work.
 
 The container will be provided as the first and only parameter to the closure, so definitions may depend on other services.
 
@@ -487,7 +487,7 @@ In addition to inferring class types, `TypedContainerInterface`, it adds type-sa
 These are primarily intended to add type safety to definitions which can be verified through static analysis (e.g. PHPStan and Psalm), but can be used in whatever way you see fit.
 Doing so outside of definitions can decrease code portability.
 
-Unlike the environnemt variable casting helpers, these _will not_ cast values from another type, but will throw an exception if there is a mismatch.
+Unlike the environment variable casting helpers, these _will not_ cast values from another type, but will throw an exception if there is a mismatch.
 
 ## Error Handling
 
@@ -513,7 +513,7 @@ This is intended to reduce unpredictable behavior of services in concurrent envi
   In PHP-DI, `factory` is just alternate syntax for defining a service through a closure.
 
 - When an interface is mapped to an implementation, the default behavior is to return the configured implementation.
-  In PHP-DI, `SomeInterface::class => autowire(SomeImplementation::class)` does NOT point to an explcitly-configured `SomeImplementation`
+  In PHP-DI, `SomeInterface::class => autowire(SomeImplementation::class)` does NOT point to an explicitly-configured `SomeImplementation`
 
 - A shorthand syntax for interface-to-implementation has been added
 

--- a/README.md
+++ b/README.md
@@ -396,10 +396,10 @@ return [
     MyClass::class,
     MyMockClass::class,
     MyInterface::class => function ($c) {
-        if ($c->get('isDevMode') {
+        if ($c->get('isDevMode')) {
             return $c->get(MyMockClass::class);
         }
-        return $c->get(MyClass::class),
+        return $c->get(MyClass::class);
     },
 ];
 ```


### PR DESCRIPTION
- Fix typos throughout README (including some missed by #72, go figure)
- Fix syntax errors in example code (missing parenthesis, comma instead of semicolon)
- Fix inconsistencies (asBool documentation, broken section reference)
- Update `env()` example to reflect actual `$_ENV` implementation