### PR TITLE
Set up spellcheck linter

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -57,3 +57,13 @@ jobs:
 
       - name: Run validate
         run: composer validate
+
+  typos:
+    name: Spell check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+
+      - name: Check spelling
+        uses: crate-ci/typos@v1

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Any other value will run the compilation process, writing the output to `AutoDet
 You may change the output directory by changing that variable (be mindful of `getcwd()`!); the default writes into Composer's `vendor` directory since it's commonly `gitignore`d.
 
 > [!NOTE]
-> As the API implies, this returns a singleton instance of the conatiner.
+> As the API implies, this returns a singleton instance of the container.
 >
 > This works well for most modern applications, as well as for transitioning older applications using a `$config = require 'config.php';` approach.
 > 
@@ -327,7 +327,7 @@ The topmost example is recommended for configuring any class that can be autowir
 > [!WARNING]
 > Dependency autowiring requires use of fully-qualified class names (FQCNs) as keys for object types (classes, interfaces, enums).
 > 
-> While you _may_ add additional aliases, you _must_ add defintions with FQCNs for autowiring to recognize that dependencies are available.
+> While you _may_ add additional aliases, you _must_ add definitions with FQCNs for autowiring to recognize that dependencies are available.
 >
 > e.g.
 > ```php
@@ -418,7 +418,7 @@ This is because the compiler cannot create an actual object instance, and thus w
 ### Closures
 
 If a closure is provided as a value, that closure will be executed when `get()` is called and the value it returns will be returned.
-This is how the above defintions work.
+This is how the above definitions work.
 
 The container will be provided as the first and only parameter to the closure, so definitions may depend on other services.
 
@@ -455,7 +455,7 @@ return [
 ### Factories
 Use the `Firehed\Container\factory` function to return a new copy of the class or value every time it is accessed through `get()`.
 
-If a paramater is not provided to the definition, the key will be used to autowire a definition.
+If a parameter is not provided to the definition, the key will be used to autowire a definition.
 If a closure is provided, that closure will be executed instead.
 
 ```php
@@ -513,7 +513,7 @@ This is intended to reduce unpredictable behavior of services in concurrent envi
   In PHP-DI, `factory` is just alternate syntax for defining a service through a closure.
 
 - When an interface is mapped to an implementation, the default behavior is to return the configured implementation.
-  In PHP-DI, `SomeInterface::class => autowire(SomeImplementation::class)` does NOT point to an explcitly-configured `SomeImplementation`
+  In PHP-DI, `SomeInterface::class => autowire(SomeImplementation::class)` does NOT point to an explicitly-configured `SomeImplementation`
 
 - A shorthand syntax for interface-to-implementation has been added
 
@@ -533,7 +533,7 @@ You may or may not agree, but it's important to document them to help you make a
 
 - Any `$id` that's a valid class string should return an instance of that class (or interface, enum).
   As of 0.6, this is reflected in the provided type information: `->get($id)` has Generic information for PHPStan where if a `class-string` is detected, get returns that class.
-  This is not (currently) enforced at runtime, but be warned that e.g. `$container->get(LoggerInterface::class);` will be indicated as being a `LoggerInteface` to static analysis tools, and if the definition doesn't do that, you may get conflicts.
+  This is not (currently) enforced at runtime, but be warned that e.g. `$container->get(LoggerInterface::class);` will be indicated as being a `LoggerInterface` to static analysis tools, and if the definition doesn't do that, you may get conflicts.
 
 - All files should always be included.
   Do NOT skip files based on the environment.

--- a/src/AutoDetect.php
+++ b/src/AutoDetect.php
@@ -51,7 +51,7 @@ final class AutoDetect
 
         if (!is_string($env) || $env === '') {
             throw new UnexpectedValueException(sprintf(
-                'Could not detect environment name. Seached envvars: %s',
+                'Could not detect environment name. Searched envvars: %s',
                 implode(', ', $envNames),
             ));
         }

--- a/src/CompiledContainer.php
+++ b/src/CompiledContainer.php
@@ -47,7 +47,7 @@ abstract class CompiledContainer implements TypedContainerInterface
         try {
             return $this->doGet($id);
         } catch (Throwable $e) {
-            if ($e instanceof Exceptions\ValueRetreivalException) {
+            if ($e instanceof Exceptions\ValueRetrievalException) {
                 $e->addId($id);
             }
             if ($e instanceof ContainerExceptionInterface) {
@@ -55,7 +55,7 @@ abstract class CompiledContainer implements TypedContainerInterface
                 throw $e;
             }
             // Repackage the error into something with a more helpful message
-            throw new Exceptions\ValueRetreivalException($id, $e);
+            throw new Exceptions\ValueRetrievalException($id, $e);
         }
     }
 

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -55,7 +55,7 @@ class Compiler implements BuilderInterface
         // @phpstan-ignore-next-line This class will be generated
         $this->className = 'CC_' . md5($path);
 
-        // If the conatiner has already been built, do nothing else.
+        // If the container has already been built, do nothing else.
         if (file_exists($path)) {
             $this->exists = true;
             $this->path = $path;

--- a/src/Compiler/AutowiredValue.php
+++ b/src/Compiler/AutowiredValue.php
@@ -23,7 +23,7 @@ class AutowiredValue implements CodeGeneratorInterface
 
     public function generateCode(): string
     {
-        // This is initialized here rather than in the defintion to allow the
+        // This is initialized here rather than in the definition to allow the
         // runtimeexception to be thrown
         $this->dependencies = [];
 

--- a/src/Compiler/ClosureValue.php
+++ b/src/Compiler/ClosureValue.php
@@ -13,7 +13,7 @@ use UnexpectedValueException;
 
 class ClosureValue implements CodeGeneratorInterface
 {
-    // This is not strictly accurate yet, but a correct implememntation
+    // This is not strictly accurate yet, but a correct implementation
     // requires pretty deep AST analysis. This should be treated as a known bug
     // for now.
     use NoDependenciesTrait;
@@ -73,7 +73,7 @@ class ClosureValue implements CodeGeneratorInterface
         // An improved version will
         //   a) Use only the body of the closure
         //   b) Replace $arg1 with $this
-        // But gettting there will take a fair bit of AST hacking.
+        // But getting there will take a fair bit of AST hacking.
         return sprintf(
             'return (%s)($this);',
             $code

--- a/src/Compiler/CodeGeneratorInterface.php
+++ b/src/Compiler/CodeGeneratorInterface.php
@@ -6,7 +6,7 @@ namespace Firehed\Container\Compiler;
 interface CodeGeneratorInterface
 {
     /**
-     * Must return PHP code that evalutes to something like this:
+     * Must return PHP code that evaluates to something like this:
      *
      *     return 'some_value';
      *

--- a/src/DevContainer.php
+++ b/src/DevContainer.php
@@ -41,7 +41,7 @@ class DevContainer implements TypedContainerInterface
         try {
             return $this->doGet($id);
         } catch (Throwable $e) {
-            if ($e instanceof Exceptions\ValueRetreivalException) {
+            if ($e instanceof Exceptions\ValueRetrievalException) {
                 $e->addId($id);
             }
             if ($e instanceof ContainerExceptionInterface) {
@@ -49,7 +49,7 @@ class DevContainer implements TypedContainerInterface
                 throw $e;
             }
             // Repackage the error into something with a more helpful message
-            throw new Exceptions\ValueRetreivalException($id, $e);
+            throw new Exceptions\ValueRetrievalException($id, $e);
         }
     }
 

--- a/src/DevContainer.php
+++ b/src/DevContainer.php
@@ -139,7 +139,7 @@ class DevContainer implements TypedContainerInterface
     }
 
     /**
-     * Returns a closure that takes the conatiner as its only argument and
+     * Returns a closure that takes the container as its only argument and
      * returns the instantiated object
      */
     private function autowire(string $class): Closure

--- a/src/Exceptions/ValueRetrievalException.php
+++ b/src/Exceptions/ValueRetrievalException.php
@@ -8,7 +8,7 @@ use Psr\Container\ContainerExceptionInterface;
 use RuntimeException;
 use Throwable;
 
-class ValueRetreivalException extends RuntimeException implements ContainerExceptionInterface
+class ValueRetrievalException extends RuntimeException implements ContainerExceptionInterface
 {
     /**
      * @var string[]

--- a/tests/ContainerBuilderTestTrait.php
+++ b/tests/ContainerBuilderTestTrait.php
@@ -82,7 +82,7 @@ trait ContainerBuilderTestTrait
     /**
      * SomeImplementation::class,
      */
-    public function testImplcitAutowiredDefinition(): void
+    public function testImplicitAutowiredDefinition(): void
     {
         $container = $this->getContainer();
         $this->assertGetSingleton(
@@ -110,7 +110,7 @@ trait ContainerBuilderTestTrait
      * SomeImplementation::class => autowire()
      * where SomeImplementation has >=1 constructor arguments
      */
-    public function testAutowiredDefinitionWithConstuctorArg(): void
+    public function testAutowiredDefinitionWithConstructorArg(): void
     {
         $container = $this->getContainer();
         $this->assertGetSingleton(
@@ -149,7 +149,7 @@ trait ContainerBuilderTestTrait
     }
 
     /**
-     * SomeInterface::class => SomeImplementation::clas;
+     * SomeInterface::class => SomeImplementation::class;
      * SomeImplementation::class => factory(...)
      */
     public function testMultipleCallsToInterfaceMappedToFactoryDefinitionWithBody(): void
@@ -193,7 +193,7 @@ trait ContainerBuilderTestTrait
      *   return useContainerValue($container);
      * }
      */
-    public function testClosureThatUsesConatiner(): void
+    public function testClosureThatUsesContainer(): void
     {
         $container = $this->getContainer();
         assert($container->has('literalValueForComplex'));

--- a/tests/EnvironmentDefinitionsTestTrait.php
+++ b/tests/EnvironmentDefinitionsTestTrait.php
@@ -90,7 +90,7 @@ trait EnvironmentDefinitionsTestTrait
     {
         $_ENV[self::$prefix . 'NONSTRING'] = 123;
         $container = $this->getContainer();
-        $this->expectException(ValueRetreivalException::class);
+        $this->expectException(ValueRetrievalException::class);
         $container->get('env_nonstring');
     }
 

--- a/tests/EnvironmentDefinitionsTestTrait.php
+++ b/tests/EnvironmentDefinitionsTestTrait.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace Firehed\Container;
 
-use Firehed\Container\Exceptions\ValueRetreivalException;
+use Firehed\Container\Exceptions\ValueRetrievalException;
 use Psr\Container\ContainerExceptionInterface;
 
 trait EnvironmentDefinitionsTestTrait

--- a/tests/ErrorDefinitionsTestTrait.php
+++ b/tests/ErrorDefinitionsTestTrait.php
@@ -29,7 +29,7 @@ trait ErrorDefinitionsTestTrait
         $c->get(Fixtures\ConstructorUntyped::class);
     }
 
-    public function testConstructorWithUndefiendTypedArgErrors(): void
+    public function testConstructorWithUndefinedTypedArgErrors(): void
     {
         $builder = $this->getBuilder();
         $builder->addFile(__DIR__ . '/ErrorDefinitions/RequiredParams.php');


### PR DESCRIPTION
And apply fixes. This includes a breaking change due to a class rename.