### PR TITLE
Handle and test dotenv interoperability

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ require 'vendor/autoload.php';
 // If using a tool like dotenv, apply it here
 /*
 if (file_exists(__DIR__.'/.env')) {
-    Dotenv\Dotenv::create(__DIR__)->load();
+    Dotenv\Dotenv::createImmutable(__DIR__)->load();
 }
  */
 
@@ -210,7 +210,20 @@ return [
 ];
 ```
 
+Environment variables will be read from `$_ENV`, and then fall back to `getenv()` if not set.
+This maximizes compatibility with most server configs and env-loading libraries, and aims to give you the "least surprise" value if conflicts exist.
 If a default value is not provided and no value is in the environment, an attempt to read will throw an exception.
+
+> [!TIP]
+> In _very specific, uncommon_ circumstances, `env()` may provide a different value than you expect.
+> The only known case is:
+>
+> 1) You use `vlucas/phpdotenv` in `createImmutable()` mode prior to configuring the container (this is recommended)
+> 2) `php.ini` has `variables_order` set where both `E` and `S` are omitted (this is a rare, non-default setting)
+> 3) You have a value defined both in a `.env` file AND the actual environment
+>
+> You'll get the `.env` value rather than native env, despite "immutable" mode.
+> This is a limitation of the dotenv library, not the container.
 
 `env()` calls are approximately equivalent to this:
 
@@ -218,10 +231,10 @@ If a default value is not provided and no value is in the environment, an attemp
 <?php
 return [
     'ENV_VAR_1' => function () {
-        if (!array_key_exists('ENV_VAR_1', $_ENV)) {
+        if (!array_key_exists('ENV_VAR_1', $_ENV) && getenv('ENV_VAR_1') === false) {
             throw new Firehed\Container\Exceptions\EnvironmentVariableNotSet('ENV_VAR_1');
         }
-        $value = $_ENV['ENV_VAR_1'];
+        $value = $_ENV['ENV_VAR_1'] ?? geteenv('ENV_VAR_1');
         if (!is_string($value)) {
             throw new TypeError('$_ENV contained a non-string value for key ENV_VAR_1');
         }
@@ -232,11 +245,11 @@ return [
 ```
 
 > [!CAUTION]
-> DO NOT use `getenv` or `$_ENV` to access environment variables!
+> DO NOT use `getenv` or `$_ENV` to access environment variables in config definitions!
 > If you do so, compiled containers will get the *compile-time* value set, which is almost certainly _not_ the behavior you want.
 > Instead, use the `env` wrapper, which will defer the access of the environment variable until the first time it is used.
 >
-> If *and only if* you want a value compiled in, you must use `getenv` directly.
+> If *and only if* you want a value compiled in, you must use `$_ENV`/`getenv` directly.
 
 #### Env casting
 

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,8 @@
         "phpstan/phpstan-phpunit": "^2.0",
         "phpstan/phpstan-strict-rules": "^2.0",
         "phpunit/phpunit": "^10.5.27",
-        "squizlabs/php_codesniffer": "^3.5"
+        "squizlabs/php_codesniffer": "^3.5",
+        "vlucas/phpdotenv": "^5.6"
     },
     "scripts": {
         "test": [

--- a/src/AutoDetect.php
+++ b/src/AutoDetect.php
@@ -41,10 +41,11 @@ final class AutoDetect
             throw new InvalidArgumentException('Directory is empty. Did you mean "."?');
         }
 
+        $reader = new EnvReader($_ENV);
         $env = null;
         foreach ($envNames as $envName) {
-            $env = $_ENV[$envName] ?? '';
-            if ($env !== '') {
+            $env = $reader->read($envName);
+            if ($env !== null && $env !== '') {
                 break;
             }
         }

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -68,7 +68,7 @@ class Builder implements BuilderInterface
         if ($this->errors !== []) {
             throw $this->errors[0];
         }
-        $container = new DevContainer($this->defs);
+        $container = new DevContainer($this->defs, new EnvReader($_ENV));
 
         return $container;
     }

--- a/src/CompiledContainer.php
+++ b/src/CompiledContainer.php
@@ -29,6 +29,10 @@ abstract class CompiledContainer implements TypedContainerInterface
      */
     protected array $mappings = [];
 
+    public function __construct(protected EnvReader $envReader)
+    {
+    }
+
     /** @return array{ids: list<string>} */
     public function __debugInfo(): array
     {

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -169,7 +169,7 @@ class Compiler implements BuilderInterface
     {
         $this->compile();
         require_once $this->path;
-        return new $this->className();
+        return new $this->className(new EnvReader($_ENV));
     }
 
     private function compile(): void

--- a/src/Compiler/EnvironmentVariableValue.php
+++ b/src/Compiler/EnvironmentVariableValue.php
@@ -20,12 +20,8 @@ class EnvironmentVariableValue implements CodeGeneratorInterface
         $envVarName = $this->env->getName();
         $cast = $this->env->getCast();
         return <<<PHP
-if (array_key_exists('$envVarName', \$_ENV)) {
-    \$value = \$_ENV['$envVarName'];
-    if (!is_string(\$value)) {
-        throw new \TypeError('\$_ENV contained a non-string value for key $envVarName');
-    }
-} else {
+\$value = \$this->envReader->read('$envVarName');
+if (\$value === null) {
     {$this->getDefaultBody()}
 }
 {$this->castBody()}

--- a/src/DevContainer.php
+++ b/src/DevContainer.php
@@ -19,7 +19,7 @@ class DevContainer implements TypedContainerInterface
     private $evaluated = [];
 
     /** @param mixed[] $definitions */
-    public function __construct(private array $definitions)
+    public function __construct(private array $definitions, private EnvReader $envReader)
     {
     }
 
@@ -94,15 +94,8 @@ class DevContainer implements TypedContainerInterface
 
         if ($value instanceof EnvironmentVariableInterface) {
             $varName = $value->getName();
-            if (array_key_exists($varName, $_ENV)) {
-                $envValue = $_ENV[$varName];
-                if (!is_string($envValue)) {
-                    throw new TypeError(sprintf(
-                        '$_ENV contained a non-string value for key %s',
-                        $varName,
-                    ));
-                }
-            } else {
+            $envValue = $this->envReader->read($varName);
+            if ($envValue === null) {
                 if ($value->hasDefault()) {
                     $envValue = $value->getDefault();
                 } else {

--- a/src/EnvReader.php
+++ b/src/EnvReader.php
@@ -12,7 +12,7 @@ class EnvReader
     private readonly array $getenv;
 
     /**
-     * @param array<string, string> $env Typically $_ENV
+     * @param mixed[] $env Typically $_ENV
      */
     public function __construct(private readonly array $env)
     {
@@ -22,8 +22,11 @@ class EnvReader
     public function read(string $key): ?string
     {
         if (array_key_exists($key, $this->env)) {
-            // check non string
-            return $this->env[$key];
+            $value = $this->env[$key];
+            if (!is_string($value)) {
+                throw new \TypeError('$_ENV contained a non-string value for key ' . $key);
+            }
+            return $value;
         }
         // if (array_key_exists($key, $this->getenv)) {
         return $this->getenv[$key] ?? null;

--- a/src/EnvReader.php
+++ b/src/EnvReader.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\Container;
+
+readonly class EnvReader
+{
+    /**
+     * @var array<string, string>
+     */
+    private array $getenv;
+
+    /**
+     * @param array<string, string> $env Typically $_ENV
+     */
+    public function __construct(private array $env)
+    {
+        $this->getenv = getenv();
+    }
+
+    public function read(string $key): ?string
+    {
+        if (array_key_exists($key, $this->env)) {
+            // check non string
+            return $this->env[$key];
+        }
+        // if (array_key_exists($key, $this->getenv)) {
+        return $this->getenv[$key] ?? null;
+    }
+
+    // todo: debuginfo
+}

--- a/src/EnvReader.php
+++ b/src/EnvReader.php
@@ -4,17 +4,17 @@ declare(strict_types=1);
 
 namespace Firehed\Container;
 
-readonly class EnvReader
+class EnvReader
 {
     /**
      * @var array<string, string>
      */
-    private array $getenv;
+    private readonly array $getenv;
 
     /**
      * @param array<string, string> $env Typically $_ENV
      */
-    public function __construct(private array $env)
+    public function __construct(private readonly array $env)
     {
         $this->getenv = getenv();
     }

--- a/tests/EnvReaderTest.php
+++ b/tests/EnvReaderTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\Container;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(EnvReader::class)]
+#[Small]
+class EnvReaderTest extends TestCase
+{
+    public function testReadFromEnvArray(): void
+    {
+        $reader = new EnvReader(['FOO' => 'bar']);
+        self::assertSame('bar', $reader->read('FOO'));
+    }
+
+    public function testReadMissingKeyReturnsNull(): void
+    {
+        $reader = new EnvReader([]);
+        self::assertNull($reader->read('NONEXISTENT'));
+    }
+
+    public function testEnvArrayTakesPrecedenceOverGetenv(): void
+    {
+        putenv('TEST_PRECEDENCE=from_getenv');
+        $reader = new EnvReader(['TEST_PRECEDENCE' => 'from_array']);
+        self::assertSame('from_array', $reader->read('TEST_PRECEDENCE'));
+        putenv('TEST_PRECEDENCE'); // cleanup
+    }
+
+    public function testFallsBackToGetenv(): void
+    {
+        putenv('TEST_FALLBACK=from_getenv');
+        $reader = new EnvReader([]);
+        self::assertSame('from_getenv', $reader->read('TEST_FALLBACK'));
+        putenv('TEST_FALLBACK'); // cleanup
+    }
+}

--- a/tests/Integration/.env
+++ b/tests/Integration/.env
@@ -1,0 +1,2 @@
+# vim: ft=sh
+FOO=dotenv

--- a/tests/Integration/DotenvMode.php
+++ b/tests/Integration/DotenvMode.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\Container\Integration;
+
+enum DotenvMode: string
+{
+    case None = 'none';
+    case Immutable = 'immutable';
+    case Mutable = 'mutable';
+    case UnsafeMutable = 'unsafe_mutable';
+    case UnsafeImmutable = 'unsafe_immutable';
+}

--- a/tests/Integration/Env.php
+++ b/tests/Integration/Env.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\Container\Integration;
+
+enum Env: string
+{
+    case Dev = 'dev';
+    case Other = 'compiled';
+}

--- a/tests/Integration/EnvTest.php
+++ b/tests/Integration/EnvTest.php
@@ -11,9 +11,18 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 #[CoversNothing]
-#[MediumSmall]
+#[Medium]
 class EnvTest extends TestCase
 {
+    public function tearDown(): void
+    {
+        // Destroy compiled container file
+        $file = __DIR__ . '/vendor/compiledConfig.php';
+        if (file_exists($file)) {
+            unlink($file);
+        }
+    }
+
     // Mode=none, all fail
     public static function noDotenvMatrix(): array
     {

--- a/tests/Integration/EnvTest.php
+++ b/tests/Integration/EnvTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\Container\Integration;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+#[Small]
+class EnvTest extends TestCase
+{
+
+    public static function envMatrix(): array
+    {
+    }
+
+    #[DataProvider('envMatrix')]
+    public function testEnvReading(DotenvMode $dotenv, VariablesOrder $order): void
+    {
+
+        // run with `php -d $order->value`
+        // inspect output
+    }
+
+}
+
+enum DotenvMode {
+  case None;
+  case Immutable;
+  case Mutable;
+  case UnsafeMutable;
+  case UnsafeImmutable;
+}
+enum VariablesOrder: string {
+  case IncludeEnv = 'EGP';
+  case ExcludeEnv = 'GP';
+}

--- a/tests/Integration/EnvTest.php
+++ b/tests/Integration/EnvTest.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace Firehed\Container\Integration;
 
-use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Small;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
+#[CoversNothing]
 #[Small]
 class EnvTest extends TestCase
 {
@@ -18,16 +19,46 @@ class EnvTest extends TestCase
     {
         $out = [];
         foreach (DotenvMode::cases() as $dotenv) {
-            foreach (VariablesOrder::cases() as $var) {
-                $out[] = [$dotenv, $var];
+            foreach (Env::cases() as $env) {
+                foreach (Override::cases() as $override) {
+                    foreach (VariablesOrder::cases() as $var) {
+                        $out[] = [$dotenv, $env, $override, $var];
+                    }
+                }
             }
         }
         return $out;
     }
 
     #[DataProvider('envMatrix')]
-    public function testEnvReading(DotenvMode $dotenv, VariablesOrder $order): void
-    {
+    public function testEnvReading(
+        DotenvMode $dotenv,
+        Env $env,
+        Override $override,
+        VariablesOrder $order,
+    ): void {
+
+        $cmd = sprintf(
+            'ENV=%s %s php -d variables_order=%s %s %s 2>&1',
+            $env->value,
+            $override->value,
+            $order->value,
+            escapeshellarg(__DIR__ . '/readenv.php'),
+            $dotenv->value,
+        );
+        // echo "$cmd\n";
+        exec($cmd, $output, $code);
+
+        $outputText = implode("\n", $output);
+        // echo $outputText;
+        self::assertSame(0, $code, 'Command exited with error');
+        // var_dump($outputText);
+
+        if ($override === Override::None) {
+            self::assertSame('dotenv', $outputText);
+        } else {
+            self::assertSame('shell', $outputText);
+        }
 
         // run with `php -d $order->value`
         // inspect output
@@ -35,14 +66,28 @@ class EnvTest extends TestCase
 
 }
 
-enum DotenvMode {
-  case None;
-  case Immutable;
-  case Mutable;
-  case UnsafeMutable;
-  case UnsafeImmutable;
+enum DotenvMode: string
+{
+    case None = 'none';
+    case Immutable = 'immutable';
+    case Mutable = 'mutable';
+    case UnsafeMutable = 'unsafe_mutable';
+    case UnsafeImmutable = 'unsafe_immutable';
 }
-enum VariablesOrder: string {
-  case IncludeEnv = 'EGP';
-  case ExcludeEnv = 'GP';
+enum VariablesOrder: string
+{
+    case IncludeEnv = 'EGP';
+    case ExcludeEnv = 'GP';
+}
+
+enum Env: string
+{
+    case Dev = 'dev';
+    case Other = 'compiled';
+}
+
+enum Override: string
+{
+    case None = '';
+    case Shell = 'FOO=shell';
 }

--- a/tests/Integration/EnvTest.php
+++ b/tests/Integration/EnvTest.php
@@ -16,6 +16,13 @@ class EnvTest extends TestCase
 
     public static function envMatrix(): array
     {
+        $out = [];
+        foreach (DotenvMode::cases() as $dotenv) {
+            foreach (VariablesOrder::cases() as $var) {
+                $out[] = [$dotenv, $var];
+            }
+        }
+        return $out;
     }
 
     #[DataProvider('envMatrix')]

--- a/tests/Integration/EnvTest.php
+++ b/tests/Integration/EnvTest.php
@@ -10,6 +10,9 @@ use PHPUnit\Framework\Attributes\Medium;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @phpstan-type Matrix array<string, array{DotenvMode, Env, Override, VariablesOrder}>
+ */
 #[CoversNothing]
 #[Medium]
 class EnvTest extends TestCase
@@ -23,7 +26,11 @@ class EnvTest extends TestCase
         }
     }
 
-    // Mode=none, all fail
+    /**
+     * No dotenv load, only native env works at all
+     *
+     * @return Matrix
+     */
     public static function noDotenvMatrix(): array
     {
         $out = [];
@@ -55,7 +62,11 @@ class EnvTest extends TestCase
         }
     }
 
-    // Mode is mutable: dotenv value always wins
+    /**
+     * Mode is mutable: dotenv value always wins
+     *
+     * @return Matrix
+     */
     public static function mutableMatrix(): array
     {
         $out = [];
@@ -87,7 +98,11 @@ class EnvTest extends TestCase
     }
 
 
-    // Mode is immutable: override value wins
+    /**
+     * Mode is immutable: override value wins
+     *
+     * @return Matrix
+     */
     public static function immutableMatrix(): array
     {
         $out = [];
@@ -128,6 +143,9 @@ class EnvTest extends TestCase
         self::assertSame($expected, $outputText);
     }
 
+    /**
+     * @param Matrix $out
+     */
     private static function buildCase(
         DotenvMode $dotenv,
         Env $env,

--- a/tests/Integration/EnvTest.php
+++ b/tests/Integration/EnvTest.php
@@ -6,23 +6,55 @@ namespace Firehed\Container\Integration;
 
 use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\Attributes\Medium;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 #[CoversNothing]
-#[Small]
+#[MediumSmall]
 class EnvTest extends TestCase
 {
-
-    public static function envMatrix(): array
+    // Mode=none, all fail
+    public static function noDotenvMatrix(): array
     {
         $out = [];
-        foreach (DotenvMode::cases() as $dotenv) {
+        foreach (Env::cases() as $env) {
+            foreach (Override::cases() as $override) {
+                foreach (VariablesOrder::cases() as $var) {
+                    self::buildCase(DotenvMode::None, $env, $override, $var, $out);
+                }
+            }
+        }
+        return $out;
+    }
+
+    #[DataProvider('noDotenvMatrix')]
+    public function testNoDotenv(
+        DotenvMode $dotenv,
+        Env $env,
+        Override $override,
+        VariablesOrder $order,
+    ): void {
+        $cmd = self::buildCommand($dotenv, $env, $override, $order);
+        exec($cmd, $output, $code);
+
+        if ($override === Override::None) {
+            self::assertSame(2, $code);
+        } else {
+            self::assertSame(0, $code);
+            self::assertSame('shell', implode("\n", $output));
+        }
+    }
+
+    // Mode is mutable: dotenv value always wins
+    public static function mutableMatrix(): array
+    {
+        $out = [];
+        foreach ([DotenvMode::Mutable, DotenvMode::UnsafeMutable] as $dotenv) {
             foreach (Env::cases() as $env) {
                 foreach (Override::cases() as $override) {
                     foreach (VariablesOrder::cases() as $var) {
-                        $out[] = [$dotenv, $env, $override, $var];
+                        self::buildCase($dotenv, $env, $override, $var, $out);
                     }
                 }
             }
@@ -30,15 +62,83 @@ class EnvTest extends TestCase
         return $out;
     }
 
-    #[DataProvider('envMatrix')]
-    public function testEnvReading(
+    #[DataProvider('mutableMatrix')]
+    public function testMutableReading(
         DotenvMode $dotenv,
         Env $env,
         Override $override,
         VariablesOrder $order,
     ): void {
+        $cmd = self::buildCommand($dotenv, $env, $override, $order);
+        exec($cmd, $output, $code);
 
-        $cmd = sprintf(
+        $outputText = implode("\n", $output);
+        self::assertSame(0, $code, 'Command exited with error: ' . $outputText);
+        self::assertSame('dotenv', $outputText);
+    }
+
+
+    // Mode is immutable: override value wins
+    public static function immutableMatrix(): array
+    {
+        $out = [];
+        foreach ([DotenvMode::Immutable, DotenvMode::UnsafeImmutable] as $dotenv) {
+            foreach (Env::cases() as $env) {
+                foreach (Override::cases() as $override) {
+                    foreach (VariablesOrder::cases() as $var) {
+                        self::buildCase($dotenv, $env, $override, $var, $out);
+                    }
+                }
+            }
+        }
+        return $out;
+    }
+
+    #[DataProvider('immutableMatrix')]
+    public function testImmutableReading(
+        DotenvMode $dotenv,
+        Env $env,
+        Override $override,
+        VariablesOrder $order,
+    ): void {
+        $cmd = self::buildCommand($dotenv, $env, $override, $order);
+        exec($cmd, $output, $code);
+
+        $outputText = implode("\n", $output);
+        self::assertSame(0, $code, 'Command exited with error: ' . $outputText);
+
+        if ($override === Override::None) {
+            self::assertSame('dotenv', $outputText);
+        } else {
+            self::assertSame('shell', $outputText);
+        }
+    }
+
+    private static function buildCase(
+        DotenvMode $dotenv,
+        Env $env,
+        Override $override,
+        VariablesOrder $order,
+        array &$out,
+    ): void {
+        $key = sprintf(
+            '%s %s %s %s',
+            $dotenv->value,
+            $env->value,
+            $override->value,
+            $order->value,
+        );
+        $out[$key] = [$dotenv, $env, $override, $order];
+    }
+
+
+    private static function buildCommand(
+        DotenvMode $dotenv,
+        Env $env,
+        Override $override,
+        VariablesOrder $order,
+    ): string {
+        return sprintf(
             'ENV=%s %s php -d variables_order=%s %s %s 2>&1',
             $env->value,
             $override->value,
@@ -46,22 +146,6 @@ class EnvTest extends TestCase
             escapeshellarg(__DIR__ . '/readenv.php'),
             $dotenv->value,
         );
-        // echo "$cmd\n";
-        exec($cmd, $output, $code);
-
-        $outputText = implode("\n", $output);
-        // echo $outputText;
-        self::assertSame(0, $code, 'Command exited with error');
-        // var_dump($outputText);
-
-        if ($override === Override::None) {
-            self::assertSame('dotenv', $outputText);
-        } else {
-            self::assertSame('shell', $outputText);
-        }
-
-        // run with `php -d $order->value`
-        // inspect output
     }
 
 }

--- a/tests/Integration/EnvTest.php
+++ b/tests/Integration/EnvTest.php
@@ -167,10 +167,13 @@ enum DotenvMode: string
     case UnsafeMutable = 'unsafe_mutable';
     case UnsafeImmutable = 'unsafe_immutable';
 }
+
 enum VariablesOrder: string
 {
-    case IncludeEnv = 'EGP';
-    case ExcludeEnv = 'GP';
+    case EnvOnly = 'EGP';
+    case EnvAndServer = 'EGPS';
+    case ServerOnly = 'GPS';
+    case Neither = 'GP';
 }
 
 enum Env: string

--- a/tests/Integration/EnvTest.php
+++ b/tests/Integration/EnvTest.php
@@ -161,34 +161,4 @@ class EnvTest extends TestCase
             $dotenv->value,
         );
     }
-
-}
-
-enum DotenvMode: string
-{
-    case None = 'none';
-    case Immutable = 'immutable';
-    case Mutable = 'mutable';
-    case UnsafeMutable = 'unsafe_mutable';
-    case UnsafeImmutable = 'unsafe_immutable';
-}
-
-enum VariablesOrder: string
-{
-    case EnvOnly = 'EGP';
-    case EnvAndServer = 'EGPS';
-    case ServerOnly = 'GPS';
-    case Neither = 'GP';
-}
-
-enum Env: string
-{
-    case Dev = 'dev';
-    case Other = 'compiled';
-}
-
-enum Override: string
-{
-    case None = '';
-    case Shell = 'FOO=shell';
 }

--- a/tests/Integration/EnvTest.php
+++ b/tests/Integration/EnvTest.php
@@ -116,11 +116,16 @@ class EnvTest extends TestCase
         $outputText = implode("\n", $output);
         self::assertSame(0, $code, 'Command exited with error: ' . $outputText);
 
-        if ($override === Override::None) {
-            self::assertSame('dotenv', $outputText);
-        } else {
-            self::assertSame('shell', $outputText);
+        $expected = 'dotenv';
+        if ($override === Override::Shell) {
+            $expected = 'shell';
+            // Edge case: phpdotenv won't recognize there's a value already set
+            // if variables_order excludes E and S, so immutability fails.
+            if ($order === VariablesOrder::Neither && $dotenv === DotenvMode::Immutable) {
+                $expected = 'dotenv';
+            }
         }
+        self::assertSame($expected, $outputText);
     }
 
     private static function buildCase(

--- a/tests/Integration/Override.php
+++ b/tests/Integration/Override.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\Container\Integration;
+
+enum Override: string
+{
+    case None = '';
+    case Shell = 'FOO=shell';
+}

--- a/tests/Integration/VariablesOrder.php
+++ b/tests/Integration/VariablesOrder.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\Container\Integration;
+
+enum VariablesOrder: string
+{
+    case EnvOnly = 'EGP';
+    case EnvAndServer = 'EGPS';
+    case ServerOnly = 'GPS';
+    case Neither = 'GP';
+}

--- a/tests/Integration/config/env.php
+++ b/tests/Integration/config/env.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use function Firehed\Container\env;
+
+return [
+    'FOO' => env('FOO'),
+];

--- a/tests/Integration/readenv.php
+++ b/tests/Integration/readenv.php
@@ -3,9 +3,14 @@
 declare(strict_types=1);
 
 use Dotenv\Dotenv;
+use Firehed\Container\AutoDetect;
+
+chdir(__DIR__);
+require __DIR__ . '/../../vendor/autoload.php';
 
 // load based on $dotenv
 
 $container = AutoDetect::from('config');
+// var_dump(get_debug_type($container));
 
 echo $container->get('FOO');

--- a/tests/Integration/readenv.php
+++ b/tests/Integration/readenv.php
@@ -10,7 +10,8 @@ chdir(__DIR__);
 require __DIR__ . '/../../vendor/autoload.php';
 
 // Hide deprecation warnings in "low" CI
-ini_set('display_errors', 'off');
+ini_set('display_errors', '0');
+error_reporting(E_ALL & ~E_DEPRECATED);
 
 if ($argc < 2) {
     throw new Exception('Argument required');

--- a/tests/Integration/readenv.php
+++ b/tests/Integration/readenv.php
@@ -23,6 +23,5 @@ if ($mode !== 'none') {
 }
 
 $container = AutoDetect::from('config');
-// var_dump(get_debug_type($container));
 
 echo $container->get('FOO');

--- a/tests/Integration/readenv.php
+++ b/tests/Integration/readenv.php
@@ -13,6 +13,7 @@ require __DIR__ . '/../../vendor/autoload.php';
 ini_set('display_errors', '0');
 error_reporting(E_ALL & ~E_DEPRECATED);
 
+assert(isset($argc) && isset($argv));
 if ($argc < 2) {
     throw new Exception('Argument required');
 };

--- a/tests/Integration/readenv.php
+++ b/tests/Integration/readenv.php
@@ -9,6 +9,9 @@ use Psr\Container\ContainerExceptionInterface;
 chdir(__DIR__);
 require __DIR__ . '/../../vendor/autoload.php';
 
+// Hide deprecation warnings in "low" CI
+ini_set('display_errors', 'off');
+
 if ($argc < 2) {
     throw new Exception('Argument required');
 };

--- a/tests/Integration/readenv.php
+++ b/tests/Integration/readenv.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Dotenv\Dotenv;
+
+// load based on $dotenv
+
+$container = AutoDetect::from('config');
+
+echo $container->get('FOO');

--- a/tests/Integration/readenv.php
+++ b/tests/Integration/readenv.php
@@ -8,7 +8,19 @@ use Firehed\Container\AutoDetect;
 chdir(__DIR__);
 require __DIR__ . '/../../vendor/autoload.php';
 
-// load based on $dotenv
+if ($argc < 2) {
+    throw new Exception('Argument required');
+};
+$mode = $argv[1];
+if ($mode !== 'none') {
+    $dotenv = match ($mode) {
+        'mutable' => Dotenv::createMutable(__DIR__),
+        'immutable' => Dotenv::createImmutable(__DIR__),
+        'unsafe_mutable' => Dotenv::createUnsafeMutable(__DIR__),
+        'unsafe_immutable' => Dotenv::createUnsafeImmutable(__DIR__),
+    };
+    $dotenv->load();
+}
 
 $container = AutoDetect::from('config');
 // var_dump(get_debug_type($container));

--- a/tests/Integration/readenv.php
+++ b/tests/Integration/readenv.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Dotenv\Dotenv;
 use Firehed\Container\AutoDetect;
+use Psr\Container\ContainerExceptionInterface;
 
 chdir(__DIR__);
 require __DIR__ . '/../../vendor/autoload.php';
@@ -22,6 +23,17 @@ if ($mode !== 'none') {
     $dotenv->load();
 }
 
-$container = AutoDetect::from('config');
+try {
+    $container = AutoDetect::from('config');
+} catch (Throwable $e) {
+    echo $e;
+    exit(1);
+}
 
-echo $container->get('FOO');
+try {
+    $foo = $container->get('FOO');
+} catch (ContainerExceptionInterface) {
+    exit(2);
+}
+
+echo $foo;

--- a/tests/Integration/readenv.php
+++ b/tests/Integration/readenv.php
@@ -32,7 +32,8 @@ try {
 
 try {
     $foo = $container->get('FOO');
-} catch (ContainerExceptionInterface) {
+} catch (ContainerExceptionInterface $e) {
+    echo $e;
     exit(2);
 }
 

--- a/tests/Integration/readenv.php
+++ b/tests/Integration/readenv.php
@@ -18,6 +18,7 @@ if ($argc < 2) {
 };
 $mode = $argv[1];
 if ($mode !== 'none') {
+    // @phpstan-ignore match.unhandled (UnhandledMatchError is desired for invalid input)
     $dotenv = match ($mode) {
         'mutable' => Dotenv::createMutable(__DIR__),
         'immutable' => Dotenv::createImmutable(__DIR__),
@@ -41,4 +42,5 @@ try {
     exit(2);
 }
 
+assert(is_string($foo));
 echo $foo;


### PR DESCRIPTION
This further adjusts how `env()` works - basically, prefer `$_ENV` to `getenv()`, but still be able to fall back to the latter instead of relying exclusively on the former.

#73

Also #60, since it now reads the envvars once at initialization for both dev and compiled containers.