### PR TITLE
Add DefinitionInterface for extensible container definitions

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -31,7 +31,7 @@ class Compiler implements BuilderInterface
     /** @var class-string<TypedContainerInterface> */
     private string $className;
 
-    /** @var Compiler\CodeGeneratorInterface[] */
+    /** @var array<string, Compiler\CodeGeneratorInterface|DefinitionInterface> */
     private array $definitions = [];
 
     /** @var array<class-string, class-string[]> */
@@ -104,7 +104,12 @@ class Compiler implements BuilderInterface
     private function add(string $key, $value): void
     {
         $this->logger->debug('Adding definition for "{key}"', ['key' => $key]);
-        if ($value instanceof FactoryInterface) {
+        if ($value instanceof DefinitionInterface) {
+            if (!$value->isCacheable()) {
+                $this->factories[$key] = true;
+            }
+            $this->definitions[$key] = $value;
+        } elseif ($value instanceof FactoryInterface) {
             $this->factories[$key] = true;
             if ($value->hasDefinition()) {
                 // Something::class => factory(fn ($container) => new Something(...))

--- a/src/DefinitionInterface.php
+++ b/src/DefinitionInterface.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\Container;
+
+/**
+ * Interface for container value definitions.
+ *
+ * Implementations define how a container entry is resolved, both at runtime
+ * (for DevContainer) and at compile-time (for compiled containers).
+ *
+ * Third-party libraries can implement this interface to provide custom
+ * value resolution strategies (e.g., fetching secrets from a vault).
+ */
+interface DefinitionInterface extends Compiler\CodeGeneratorInterface
+{
+    /**
+     * Resolve the value at runtime.
+     *
+     * @param TypedContainerInterface $container The container instance
+     * @param EnvReader $envReader Environment variable reader
+     * @return mixed The resolved value
+     */
+    public function resolve(TypedContainerInterface $container, EnvReader $envReader): mixed;
+
+    /**
+     * Whether the resolved value should be cached.
+     *
+     * Return false for factory definitions where each call should produce
+     * a new instance.
+     */
+    public function isCacheable(): bool;
+}

--- a/src/DefinitionInterface.php
+++ b/src/DefinitionInterface.php
@@ -12,6 +12,8 @@ namespace Firehed\Container;
  *
  * Third-party libraries can implement this interface to provide custom
  * value resolution strategies (e.g., fetching secrets from a vault).
+ *
+ * @internal for now, this will become public later
  */
 interface DefinitionInterface extends Compiler\CodeGeneratorInterface
 {

--- a/src/DevContainer.php
+++ b/src/DevContainer.php
@@ -69,6 +69,14 @@ class DevContainer implements TypedContainerInterface
 
         $def = $this->definitions[$id];
 
+        if ($def instanceof DefinitionInterface) {
+            $result = $def->resolve($this, $this->envReader);
+            if ($def->isCacheable()) {
+                $this->evaluated[$id] = $result;
+            }
+            return $result;
+        }
+
         if ($def instanceof AutowireInterface) {
             $classToAutowire = $def->getWiredClass() ?? $id;
             $value = $this->autowire($classToAutowire);

--- a/tests/ContainerBuilderTestTrait.php
+++ b/tests/ContainerBuilderTestTrait.php
@@ -18,6 +18,7 @@ use SessionIdInterface;
  */
 trait ContainerBuilderTestTrait
 {
+    use CustomDefinitionTestTrait;
     use EnvironmentDefinitionsTestTrait;
     use ErrorDefinitionsTestTrait;
 
@@ -36,6 +37,7 @@ trait ContainerBuilderTestTrait
     private static function getDefinitionFiles(): array
     {
         $files = [
+            'CustomDefinitions',
             'Environment',
             'CaseSensitive',
             'RequiredParams',

--- a/tests/CustomDefinitionTestTrait.php
+++ b/tests/CustomDefinitionTestTrait.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\Container;
+
+/**
+ * Tests for DefinitionInterface support
+ */
+trait CustomDefinitionTestTrait
+{
+    abstract public function getContainer(): TypedContainerInterface;
+
+    public function testCustomDefinitionString(): void
+    {
+        $container = $this->getContainer();
+        $this->assertTrue($container->has('custom_string'));
+        $this->assertSame('hello from custom', $container->get('custom_string'));
+    }
+
+    public function testCustomDefinitionInt(): void
+    {
+        $container = $this->getContainer();
+        $this->assertTrue($container->has('custom_int'));
+        $this->assertSame(42, $container->get('custom_int'));
+    }
+
+    public function testCustomDefinitionArray(): void
+    {
+        $container = $this->getContainer();
+        $this->assertTrue($container->has('custom_array'));
+        $this->assertSame(['a', 'b', 'c'], $container->get('custom_array'));
+    }
+
+    public function testCustomDefinitionCacheableReturnsSameInstance(): void
+    {
+        $container = $this->getContainer();
+        $first = $container->get('custom_cacheable');
+        $second = $container->get('custom_cacheable');
+        $this->assertSame($first, $second);
+    }
+
+    public function testCustomDefinitionFactoryReturnsValue(): void
+    {
+        $container = $this->getContainer();
+        $this->assertSame('not cached', $container->get('custom_factory'));
+    }
+}

--- a/tests/Fixtures/CustomDefinition.php
+++ b/tests/Fixtures/CustomDefinition.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\Container\Fixtures;
+
+use Firehed\Container\DefinitionInterface;
+use Firehed\Container\EnvReader;
+use Firehed\Container\TypedContainerInterface;
+
+/**
+ * Test fixture implementing DefinitionInterface.
+ * Simulates a third-party custom definition.
+ */
+class CustomDefinition implements DefinitionInterface
+{
+    public function __construct(
+        private mixed $value,
+        private bool $cacheable = true,
+    ) {
+    }
+
+    public function generateCode(): string
+    {
+        return sprintf('return %s;', var_export($this->value, true));
+    }
+
+    /** @return class-string[] */
+    public function getDependencies(): array
+    {
+        return [];
+    }
+
+    public function resolve(TypedContainerInterface $container, EnvReader $envReader): mixed
+    {
+        return $this->value;
+    }
+
+    public function isCacheable(): bool
+    {
+        return $this->cacheable;
+    }
+}

--- a/tests/ValidDefinitions/CustomDefinitions.php
+++ b/tests/ValidDefinitions/CustomDefinitions.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use Firehed\Container\Fixtures\CustomDefinition;
+
+return [
+    'custom_string' => new CustomDefinition('hello from custom'),
+    'custom_int' => new CustomDefinition(42),
+    'custom_array' => new CustomDefinition(['a', 'b', 'c']),
+    'custom_cacheable' => new CustomDefinition('cached', cacheable: true),
+    'custom_factory' => new CustomDefinition('not cached', cacheable: false),
+];


### PR DESCRIPTION
## Summary

- Introduces `DefinitionInterface` which extends `CodeGeneratorInterface` and adds `resolve()` and `isCacheable()` methods
- Both `Compiler` and `DevContainer` now check for `DefinitionInterface` first, enabling third-party extensibility
- No changes to existing behavior - purely additive infrastructure

## Test plan

- [x] Added `CustomDefinition` test fixture implementing the interface
- [x] Added tests for string, int, array values
- [x] Added tests for cacheable vs non-cacheable (factory) behavior
- [x] All 267 tests pass

Fixes #63 

---

🤖 Generated with [Claude Code](https://claude.ai/code)