### PR TITLE
Add config generator for discovering autowire-eligible classes

### DIFF
--- a/bin/generate-config
+++ b/bin/generate-config
@@ -94,6 +94,16 @@ try {
 
     $output = $generator->generate();
 
+    // Report any errors that occurred while checking classes
+    $errors = $generator->getErrors();
+    if ($errors !== []) {
+        fwrite(STDERR, sprintf("Warning: %d class(es) could not be checked:\n\n", count($errors)));
+        foreach ($errors as $className => $error) {
+            fwrite(STDERR, sprintf("  %s\n", $className));
+            fwrite(STDERR, sprintf("    %s: %s\n\n", get_class($error), $error->getMessage()));
+        }
+    }
+
     if ($outputFile !== null) {
         file_put_contents($outputFile, $output);
         fwrite(STDERR, "Config written to: $outputFile\n");

--- a/bin/generate-config
+++ b/bin/generate-config
@@ -93,22 +93,26 @@ try {
     }
 
     $output = $generator->generate();
-
-    // Report any errors that occurred while checking classes
     $errors = $generator->getErrors();
-    if ($errors !== []) {
-        fwrite(STDERR, sprintf("Warning: %d class(es) could not be checked:\n\n", count($errors)));
-        foreach ($errors as $className => $error) {
-            fwrite(STDERR, sprintf("  %s\n", $className));
-            fwrite(STDERR, sprintf("    %s: %s\n\n", get_class($error), $error->getMessage()));
-        }
-    }
 
+    // Output the generated config first
     if ($outputFile !== null) {
         file_put_contents($outputFile, $output);
         fwrite(STDERR, "Config written to: $outputFile\n");
     } else {
         echo $output;
+    }
+
+    // Report any errors at the end so they're visible
+    if ($errors !== []) {
+        fwrite(STDERR, sprintf("\nWarning: %d class(es) could not be checked:\n\n", count($errors)));
+        foreach ($errors as $className => $info) {
+            $error = $info['error'];
+            $file = $info['file'];
+            fwrite(STDERR, sprintf("  %s\n", $className));
+            fwrite(STDERR, sprintf("    File: %s\n", $file));
+            fwrite(STDERR, sprintf("    %s: %s\n\n", get_class($error), $error->getMessage()));
+        }
     }
 } catch (RuntimeException $e) {
     fwrite(STDERR, "Error: " . $e->getMessage() . "\n");

--- a/bin/generate-config
+++ b/bin/generate-config
@@ -1,0 +1,129 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+// Find autoloader
+$autoloadPaths = [
+    __DIR__ . '/../vendor/autoload.php', // When run from this repo
+    __DIR__ . '/../../../autoload.php',  // When installed as a dependency
+];
+
+$autoloaded = false;
+foreach ($autoloadPaths as $path) {
+    if (file_exists($path)) {
+        require $path;
+        $autoloaded = true;
+        break;
+    }
+}
+
+if (!$autoloaded) {
+    fwrite(STDERR, "Could not find Composer autoloader.\n");
+    exit(1);
+}
+
+use Firehed\Container\ConfigGenerator;
+
+// Parse arguments
+$args = array_slice($argv, 1);
+$directories = [];
+$excludeFiles = [];
+$outputFile = null;
+
+for ($i = 0; $i < count($args); $i++) {
+    $arg = $args[$i];
+
+    if ($arg === '--help' || $arg === '-h') {
+        printUsage();
+        exit(0);
+    }
+
+    if ($arg === '--exclude' || $arg === '-e') {
+        if (!isset($args[$i + 1])) {
+            fwrite(STDERR, "Error: --exclude requires a file path\n");
+            exit(1);
+        }
+        $excludeFiles[] = $args[++$i];
+        continue;
+    }
+
+    if ($arg === '--output' || $arg === '-o') {
+        if (!isset($args[$i + 1])) {
+            fwrite(STDERR, "Error: --output requires a file path\n");
+            exit(1);
+        }
+        $outputFile = $args[++$i];
+        continue;
+    }
+
+    if (str_starts_with($arg, '-')) {
+        fwrite(STDERR, "Unknown option: $arg\n");
+        printUsage();
+        exit(1);
+    }
+
+    $directories[] = $arg;
+}
+
+if ($directories === []) {
+    fwrite(STDERR, "Error: At least one directory is required\n\n");
+    printUsage();
+    exit(1);
+}
+
+// Run the generator
+try {
+    $generator = new ConfigGenerator();
+
+    foreach ($directories as $dir) {
+        if (!is_dir($dir)) {
+            fwrite(STDERR, "Error: Directory not found: $dir\n");
+            exit(1);
+        }
+        $generator->addDirectory($dir);
+    }
+
+    foreach ($excludeFiles as $file) {
+        if (!file_exists($file)) {
+            fwrite(STDERR, "Error: Exclude file not found: $file\n");
+            exit(1);
+        }
+        $generator->excludeFromFile($file);
+    }
+
+    $output = $generator->generate();
+
+    if ($outputFile !== null) {
+        file_put_contents($outputFile, $output);
+        fwrite(STDERR, "Config written to: $outputFile\n");
+    } else {
+        echo $output;
+    }
+} catch (RuntimeException $e) {
+    fwrite(STDERR, "Error: " . $e->getMessage() . "\n");
+    exit(1);
+}
+
+function printUsage(): void
+{
+    $script = basename($GLOBALS['argv'][0]);
+    echo <<<USAGE
+Usage: $script [options] <directory> [directory...]
+
+Scans directories for autowire-eligible classes and generates a container
+configuration file.
+
+Options:
+  -o, --output <file>   Write output to file instead of stdout
+  -e, --exclude <file>  Exclude classes already defined in config file
+                        (can be specified multiple times)
+  -h, --help            Show this help message
+
+Examples:
+  $script src/Services src/Repositories
+  $script -o config/autowired.php src/
+  $script -e config/manual.php -o config/autowired.php src/
+
+USAGE;
+}

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,14 @@
         "psr/container": "^1.0 || ^2.0",
         "psr/log": "^1.1 || ^2.0 || ^3.0"
     },
+    "suggest": {
+        "composer/class-map-generator": "Required for the config generator CLI tool"
+    },
+    "bin": [
+        "bin/generate-config"
+    ],
     "require-dev": {
+        "composer/class-map-generator": "^1.7",
         "phpstan/phpstan": "^2.0",
         "phpstan/phpstan-phpunit": "^2.0",
         "phpstan/phpstan-strict-rules": "^2.0",

--- a/src/Autowire.php
+++ b/src/Autowire.php
@@ -104,9 +104,13 @@ class Autowire
      * Check if a class can be autowired based on its constructor signature.
      *
      * @param class-string $className
+     * @throws \Throwable If the class cannot be loaded (e.g., has side effects or broken dependencies)
      */
     public static function isEligible(string $className): bool
     {
+        // ReflectionClass constructor triggers autoloading, which can fail if
+        // the class has side effects or broken dependencies at include-time.
+        // We let this propagate so callers can handle/report it appropriately.
         $rc = new ReflectionClass($className);
 
         if (!$rc->isInstantiable()) {

--- a/src/ConfigGenerator.php
+++ b/src/ConfigGenerator.php
@@ -6,6 +6,7 @@ namespace Firehed\Container;
 
 use Composer\ClassMapGenerator\ClassMapGenerator;
 use RuntimeException;
+use Throwable;
 
 /**
  * Discovers autowire-eligible classes and generates container configuration.
@@ -16,6 +17,9 @@ class ConfigGenerator
 
     /** @var list<class-string> */
     private array $excludedClasses = [];
+
+    /** @var array<class-string, Throwable> */
+    private array $errors = [];
 
     public function __construct()
     {
@@ -85,19 +89,37 @@ class ConfigGenerator
     public function getEligibleClasses(): array
     {
         $classMap = $this->scanner->getClassMap();
+        $this->errors = [];
 
         $eligible = [];
         foreach ($classMap->getMap() as $className => $path) {
             if (in_array($className, $this->excludedClasses, true)) {
                 continue;
             }
-            if (Autowire::isEligible($className)) {
-                $eligible[] = $className;
+            try {
+                if (Autowire::isEligible($className)) {
+                    $eligible[] = $className;
+                }
+            } catch (Throwable $e) {
+                $this->errors[$className] = $e;
             }
         }
 
         sort($eligible);
         return $eligible;
+    }
+
+    /**
+     * Get errors that occurred while checking class eligibility.
+     *
+     * These are typically caused by classes that have side effects or
+     * broken dependencies when loaded via the autoloader.
+     *
+     * @return array<class-string, Throwable>
+     */
+    public function getErrors(): array
+    {
+        return $this->errors;
     }
 
     /**

--- a/src/ConfigGenerator.php
+++ b/src/ConfigGenerator.php
@@ -18,7 +18,7 @@ class ConfigGenerator
     /** @var list<class-string> */
     private array $excludedClasses = [];
 
-    /** @var array<class-string, Throwable> */
+    /** @var array<class-string, array{error: Throwable, file: string}> */
     private array $errors = [];
 
     public function __construct()
@@ -96,12 +96,16 @@ class ConfigGenerator
             if (in_array($className, $this->excludedClasses, true)) {
                 continue;
             }
+            // Suppress warnings/deprecations during autoload - they're noise
+            $previousLevel = error_reporting(E_ERROR);
             try {
                 if (Autowire::isEligible($className)) {
                     $eligible[] = $className;
                 }
             } catch (Throwable $e) {
-                $this->errors[$className] = $e;
+                $this->errors[$className] = ['error' => $e, 'file' => $path];
+            } finally {
+                error_reporting($previousLevel);
             }
         }
 
@@ -115,7 +119,7 @@ class ConfigGenerator
      * These are typically caused by classes that have side effects or
      * broken dependencies when loaded via the autoloader.
      *
-     * @return array<class-string, Throwable>
+     * @return array<class-string, array{error: Throwable, file: string}>
      */
     public function getErrors(): array
     {

--- a/src/ConfigGenerator.php
+++ b/src/ConfigGenerator.php
@@ -20,10 +20,13 @@ class ConfigGenerator
     public function __construct()
     {
         if (!class_exists(ClassMapGenerator::class)) {
+            // Unreachable in testing since it's a dev-dependency
+            // @codeCoverageIgnoreStart
             throw new RuntimeException(
                 'The config generator requires composer/class-map-generator. ' .
                 'Install it with: composer require composer/class-map-generator'
             );
+            // @codeCoverageIgnoreEnd
         }
         $this->scanner = new ClassMapGenerator();
     }

--- a/src/ConfigGenerator.php
+++ b/src/ConfigGenerator.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\Container;
+
+use Composer\ClassMapGenerator\ClassMapGenerator as ComposerClassMapGenerator;
+use ReflectionClass;
+use ReflectionNamedType;
+use RuntimeException;
+
+/**
+ * Discovers autowire-eligible classes and generates container configuration.
+ */
+class ConfigGenerator
+{
+    private ComposerClassMapGenerator $scanner;
+
+    /** @var list<class-string> */
+    private array $excludedClasses = [];
+
+    public function __construct()
+    {
+        if (!class_exists(ComposerClassMapGenerator::class)) {
+            throw new RuntimeException(
+                'The config generator requires composer/class-map-generator. ' .
+                'Install it with: composer require composer/class-map-generator'
+            );
+        }
+        $this->scanner = new ComposerClassMapGenerator();
+    }
+
+    /**
+     * Add a directory to scan for classes.
+     */
+    public function addDirectory(string $directory): self
+    {
+        $this->scanner->scanPaths($directory);
+        return $this;
+    }
+
+    /**
+     * Exclude classes that are already defined in an existing config file.
+     *
+     * @param string $configFile Path to a PHP file that returns an array
+     */
+    public function excludeFromFile(string $configFile): self
+    {
+        $definitions = require $configFile;
+        if (!is_array($definitions)) {
+            throw new \InvalidArgumentException(sprintf(
+                'Config file "%s" did not return an array',
+                $configFile
+            ));
+        }
+
+        foreach ($definitions as $key => $value) {
+            // Handle both `ClassName::class,` and `ClassName::class => ...`
+            $className = is_int($key) ? $value : $key;
+            if (is_string($className) && class_exists($className)) {
+                $this->excludedClasses[] = $className;
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * Exclude specific classes from generation.
+     *
+     * @param class-string ...$classes
+     */
+    public function exclude(string ...$classes): self
+    {
+        array_push($this->excludedClasses, ...$classes);
+        return $this;
+    }
+
+    /**
+     * Get the list of discovered autowire-eligible classes.
+     *
+     * @return list<class-string>
+     */
+    public function getEligibleClasses(): array
+    {
+        $classMap = $this->scanner->getClassMap();
+
+        $eligible = [];
+        foreach ($classMap->getMap() as $className => $path) {
+            if (in_array($className, $this->excludedClasses, true)) {
+                continue;
+            }
+            if ($this->isAutowireEligible($className)) {
+                $eligible[] = $className;
+            }
+        }
+
+        sort($eligible);
+        return $eligible;
+    }
+
+    /**
+     * Generate the PHP config file content.
+     */
+    public function generate(): string
+    {
+        $classes = $this->getEligibleClasses();
+
+        $lines = ["<?php", "", "declare(strict_types=1);", "", "return ["];
+        foreach ($classes as $class) {
+            $lines[] = sprintf("    \\%s::class,", $class);
+        }
+        $lines[] = "];";
+        $lines[] = "";
+
+        return implode("\n", $lines);
+    }
+
+    /**
+     * @param class-string $className
+     */
+    private function isAutowireEligible(string $className): bool
+    {
+        $rc = new ReflectionClass($className);
+
+        // Skip abstract classes, interfaces, traits, enums
+        if ($rc->isAbstract() || $rc->isInterface() || $rc->isTrait() || $rc->isEnum()) {
+            return false;
+        }
+
+        // No constructor = eligible
+        if (!$rc->hasMethod('__construct')) {
+            return true;
+        }
+
+        $constructor = $rc->getMethod('__construct');
+
+        // Private/protected constructor = not eligible
+        if (!$constructor->isPublic()) {
+            return false;
+        }
+
+        // Check each parameter
+        foreach ($constructor->getParameters() as $param) {
+            // Optional parameters are always fine
+            if ($param->isOptional()) {
+                continue;
+            }
+
+            // Required parameter must be typed
+            if (!$param->hasType()) {
+                return false;
+            }
+
+            $type = $param->getType();
+
+            // Must be a named type (not union/intersection for now)
+            if (!$type instanceof ReflectionNamedType) {
+                return false;
+            }
+
+            // Must not be a builtin type
+            if ($type->isBuiltin()) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/ConfigGenerator.php
+++ b/src/ConfigGenerator.php
@@ -4,11 +4,7 @@ declare(strict_types=1);
 
 namespace Firehed\Container;
 
-use Closure;
 use Composer\ClassMapGenerator\ClassMapGenerator;
-use Generator;
-use ReflectionClass;
-use ReflectionNamedType;
 use RuntimeException;
 
 /**
@@ -16,16 +12,6 @@ use RuntimeException;
  */
 class ConfigGenerator
 {
-    /**
-     * Types that cannot meaningfully be autowired from a container.
-     * These are internal PHP types that are not instantiable or are
-     * created through special language constructs.
-     */
-    private const NON_AUTOWIRABLE_TYPES = [
-        Closure::class,
-        Generator::class,
-    ];
-
     private ClassMapGenerator $scanner;
 
     /** @var list<class-string> */
@@ -102,7 +88,7 @@ class ConfigGenerator
             if (in_array($className, $this->excludedClasses, true)) {
                 continue;
             }
-            if ($this->isAutowireEligible($className)) {
+            if (Autowire::isEligible($className)) {
                 $eligible[] = $className;
             }
         }
@@ -126,62 +112,5 @@ class ConfigGenerator
         $lines[] = "";
 
         return implode("\n", $lines);
-    }
-
-    /**
-     * @param class-string $className
-     */
-    private function isAutowireEligible(string $className): bool
-    {
-        $rc = new ReflectionClass($className);
-
-        // Skip abstract classes, interfaces, traits, enums
-        if ($rc->isAbstract() || $rc->isInterface() || $rc->isTrait() || $rc->isEnum()) {
-            return false;
-        }
-
-        // No constructor = eligible
-        if (!$rc->hasMethod('__construct')) {
-            return true;
-        }
-
-        $constructor = $rc->getMethod('__construct');
-
-        // Private/protected constructor = not eligible
-        if (!$constructor->isPublic()) {
-            return false;
-        }
-
-        // Check each parameter
-        foreach ($constructor->getParameters() as $param) {
-            // Optional parameters are always fine
-            if ($param->isOptional()) {
-                continue;
-            }
-
-            // Required parameter must be typed
-            if (!$param->hasType()) {
-                return false;
-            }
-
-            $type = $param->getType();
-
-            // Must be a named type (not union/intersection for now)
-            if (!$type instanceof ReflectionNamedType) {
-                return false;
-            }
-
-            // Must not be a builtin type
-            if ($type->isBuiltin()) {
-                return false;
-            }
-
-            // Filter out types that can't be in a container
-            if (in_array($type->getName(), self::NON_AUTOWIRABLE_TYPES, true)) {
-                return false;
-            }
-        }
-
-        return true;
     }
 }

--- a/src/ConfigGenerator.php
+++ b/src/ConfigGenerator.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Firehed\Container;
 
-use Composer\ClassMapGenerator\ClassMapGenerator as ComposerClassMapGenerator;
+use Closure;
+use Composer\ClassMapGenerator\ClassMapGenerator;
+use Generator;
 use ReflectionClass;
 use ReflectionNamedType;
 use RuntimeException;
@@ -14,20 +16,30 @@ use RuntimeException;
  */
 class ConfigGenerator
 {
-    private ComposerClassMapGenerator $scanner;
+    /**
+     * Types that cannot meaningfully be autowired from a container.
+     * These are internal PHP types that are not instantiable or are
+     * created through special language constructs.
+     */
+    private const NON_AUTOWIRABLE_TYPES = [
+        Closure::class,
+        Generator::class,
+    ];
+
+    private ClassMapGenerator $scanner;
 
     /** @var list<class-string> */
     private array $excludedClasses = [];
 
     public function __construct()
     {
-        if (!class_exists(ComposerClassMapGenerator::class)) {
+        if (!class_exists(ClassMapGenerator::class)) {
             throw new RuntimeException(
                 'The config generator requires composer/class-map-generator. ' .
                 'Install it with: composer require composer/class-map-generator'
             );
         }
-        $this->scanner = new ComposerClassMapGenerator();
+        $this->scanner = new ClassMapGenerator();
     }
 
     /**
@@ -161,6 +173,11 @@ class ConfigGenerator
 
             // Must not be a builtin type
             if ($type->isBuiltin()) {
+                return false;
+            }
+
+            // Filter out types that can't be in a container
+            if (in_array($type->getName(), self::NON_AUTOWIRABLE_TYPES, true)) {
                 return false;
             }
         }

--- a/tests/ConfigGeneratorTest.php
+++ b/tests/ConfigGeneratorTest.php
@@ -29,6 +29,8 @@ class ConfigGeneratorTest extends TestCase
         self::assertNotContains(Fixtures\ConstructorUntyped::class, $classes);
         self::assertNotContains(Fixtures\EmptyInterface::class, $classes);
         self::assertNotContains(Fixtures\Environment::class, $classes);
+        // Closure cannot be autowired
+        self::assertNotContains(Fixtures\RequiresClosure::class, $classes);
     }
 
     public function testExcludeRemovesClasses(): void

--- a/tests/ConfigGeneratorTest.php
+++ b/tests/ConfigGeneratorTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\Container;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers Firehed\Container\ConfigGenerator
+ */
+class ConfigGeneratorTest extends TestCase
+{
+    public function testScanFindsEligibleClasses(): void
+    {
+        $generator = new ConfigGenerator();
+        $generator->addDirectory(__DIR__ . '/Fixtures');
+
+        $classes = $generator->getEligibleClasses();
+
+        // These should be found (autowire-eligible)
+        self::assertContains(Fixtures\SessionId::class, $classes);
+        self::assertContains(Fixtures\SessionHandler::class, $classes);
+        self::assertContains(Fixtures\OptionalScalarParam::class, $classes);
+        self::assertContains(Fixtures\NoConstructorFactory::class, $classes);
+
+        // These should NOT be found
+        self::assertNotContains(Fixtures\ConstructorScalar::class, $classes);
+        self::assertNotContains(Fixtures\ConstructorUntyped::class, $classes);
+        self::assertNotContains(Fixtures\EmptyInterface::class, $classes);
+        self::assertNotContains(Fixtures\Environment::class, $classes);
+    }
+
+    public function testExcludeRemovesClasses(): void
+    {
+        $generator = new ConfigGenerator();
+        $generator->addDirectory(__DIR__ . '/Fixtures');
+        $generator->exclude(Fixtures\SessionId::class);
+
+        $classes = $generator->getEligibleClasses();
+
+        self::assertNotContains(Fixtures\SessionId::class, $classes);
+        self::assertContains(Fixtures\SessionHandler::class, $classes);
+    }
+
+    public function testExcludeFromFileRemovesDefinedClasses(): void
+    {
+        $generator = new ConfigGenerator();
+        $generator->addDirectory(__DIR__ . '/Fixtures');
+        $generator->excludeFromFile(__DIR__ . '/ValidDefinitions/NoParams.php');
+
+        $classes = $generator->getEligibleClasses();
+
+        // These are defined as keys in NoParams.php
+        self::assertNotContains(Fixtures\SessionId::class, $classes);
+        self::assertNotContains(Fixtures\SessionIdImplicit::class, $classes);
+        // SessionIdManual is a value (autowire target), not a key, so still included
+        self::assertContains(Fixtures\SessionIdManual::class, $classes);
+    }
+
+    public function testGenerateProducesValidPhp(): void
+    {
+        $generator = new ConfigGenerator();
+        $generator->addDirectory(__DIR__ . '/Fixtures');
+
+        $output = $generator->generate();
+
+        self::assertStringStartsWith("<?php\n", $output);
+        self::assertStringContainsString('declare(strict_types=1);', $output);
+        self::assertStringContainsString('return [', $output);
+        self::assertStringContainsString(Fixtures\SessionId::class . '::class,', $output);
+    }
+
+    public function testAddDirectoryThrowsForNonexistentDirectory(): void
+    {
+        $generator = new ConfigGenerator();
+
+        $this->expectException(\RuntimeException::class);
+        $generator->addDirectory('/nonexistent/path');
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `ConfigGenerator` service that scans directories for classes with autowire-compatible constructors
- Includes CLI tool (`bin/generate-config`) for easy command-line usage
- Uses `composer/class-map-generator` for class discovery (added as dev dependency and in `suggest`)

## Usage

**CLI:**
```bash
vendor/bin/generate-config src/Services src/Repositories
vendor/bin/generate-config -o config/autowired.php src/
vendor/bin/generate-config -e config/manual.php -o config/autowired.php src/
```

**Programmatic:**
```php
$generator = new ConfigGenerator();
$generator->addDirectory('src/Services');
$generator->excludeFromFile('config/manual.php');
file_put_contents('config/autowired.php', $generator->generate());
```

## Eligibility criteria

A class is considered autowire-eligible if:
- Concrete class (not abstract/interface/trait/enum)
- Public constructor (or no constructor)
- All required params typed with non-builtin types
- No `Closure` or `Generator` typed params

Closes #77

## Test plan

- [x] Unit tests for ConfigGenerator
- [x] Manual testing of CLI tool
- [ ] Test on a real project

🤖 Generated with [Claude Code](https://claude.com/claude-code)