### PR TITLE
Extract Autowire utility for shared eligibility checks

### DIFF
--- a/src/Autowire.php
+++ b/src/Autowire.php
@@ -113,17 +113,13 @@ class Autowire
             return false;
         }
 
+        // No constructor = eligible
         if (!$rc->hasMethod('__construct')) {
             return true;
         }
 
-        $constructor = $rc->getMethod('__construct');
-
-        if (!$constructor->isPublic()) {
-            return false;
-        }
-
-        foreach ($constructor->getParameters() as $param) {
+        // Non-public constructors are already excluded by isInstantiable() above
+        foreach ($rc->getMethod('__construct')->getParameters() as $param) {
             if (!self::isParameterAutowirable($param)) {
                 return false;
             }

--- a/src/Autowire.php
+++ b/src/Autowire.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\Container;
+
+use Closure;
+use Generator;
+use ReflectionClass;
+use ReflectionNamedType;
+use ReflectionParameter;
+
+/**
+ * Utilities for analyzing autowire compatibility.
+ *
+ * @internal
+ */
+class Autowire
+{
+    /**
+     * Types that cannot meaningfully be autowired from a container.
+     * These are internal PHP types that are not instantiable or are
+     * created through special language constructs.
+     */
+    private const NON_AUTOWIRABLE_TYPES = [
+        Closure::class,
+        Generator::class,
+    ];
+
+    /**
+     * Get the dependency type name for a required parameter.
+     *
+     * This validates that the parameter can be autowired and returns
+     * the fully-qualified class/interface name to resolve.
+     *
+     * @param class-string $declaringClass The class containing this parameter (for error messages)
+     * @return class-string The type to resolve from the container
+     * @throws Exceptions\UntypedValue If the parameter cannot be autowired
+     */
+    public static function getRequiredDependencyType(
+        ReflectionParameter $param,
+        string $declaringClass,
+    ): string {
+        if (!$param->hasType()) {
+            throw new Exceptions\UntypedValue($param->getName(), $declaringClass);
+        }
+
+        $type = $param->getType();
+
+        // TODO: support ReflectionUnionType (#35), ReflectionIntersectionType (#36)?
+        if (!$type instanceof ReflectionNamedType) {
+            throw new Exceptions\UntypedValue($param->getName(), $declaringClass);
+        }
+
+        if ($type->isBuiltin()) {
+            throw new Exceptions\UntypedValue($param->getName(), $declaringClass);
+        }
+
+        $typeName = $type->getName();
+
+        if (in_array($typeName, self::NON_AUTOWIRABLE_TYPES, true)) {
+            throw new Exceptions\UntypedValue($param->getName(), $declaringClass);
+        }
+
+        /** @var class-string */
+        return $typeName;
+    }
+
+    /**
+     * Check if a constructor parameter can be autowired.
+     *
+     * A parameter is autowirable if:
+     * - It is optional (has a default value), OR
+     * - It is typed with a non-builtin class/interface type
+     */
+    public static function isParameterAutowirable(ReflectionParameter $param): bool
+    {
+        if ($param->isOptional()) {
+            return true;
+        }
+
+        if (!$param->hasType()) {
+            return false;
+        }
+
+        $type = $param->getType();
+
+        if (!$type instanceof ReflectionNamedType) {
+            return false;
+        }
+
+        if ($type->isBuiltin()) {
+            return false;
+        }
+
+        if (in_array($type->getName(), self::NON_AUTOWIRABLE_TYPES, true)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Check if a class can be autowired based on its constructor signature.
+     *
+     * @param class-string $className
+     */
+    public static function isEligible(string $className): bool
+    {
+        $rc = new ReflectionClass($className);
+
+        if (!$rc->isInstantiable()) {
+            return false;
+        }
+
+        if (!$rc->hasMethod('__construct')) {
+            return true;
+        }
+
+        $constructor = $rc->getMethod('__construct');
+
+        if (!$constructor->isPublic()) {
+            return false;
+        }
+
+        foreach ($constructor->getParameters() as $param) {
+            if (!self::isParameterAutowirable($param)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/Compiler/AutowiredValue.php
+++ b/src/Compiler/AutowiredValue.php
@@ -4,11 +4,9 @@ declare(strict_types=1);
 namespace Firehed\Container\Compiler;
 
 use BadMethodCallException;
-use Firehed\Container\Exceptions\UntypedValue;
+use Firehed\Container\Autowire;
 use ReflectionClass;
 use ReflectionParameter;
-use ReflectionNamedType;
-use ReflectionType;
 
 class AutowiredValue implements CodeGeneratorInterface
 {
@@ -62,23 +60,11 @@ PHP;
         if ($param->isOptional()) {
             return var_export($param->getDefaultValue(), true);
         }
-        if (!$param->hasType()) {
-            throw new UntypedValue($param->getName(), $this->classToAutowire);
-        }
-        $type = $param->getType();
-        assert($type instanceof ReflectionType);
-        // TODO: support ReflectionUnionType (#35), ReflectionIntersectionType (#36)?
-        if (!$type instanceof ReflectionNamedType || $type->isBuiltin()) {
-            throw new UntypedValue($param->getName(), $this->classToAutowire);
-            // this would be good for non-builtins???
-            // throw NotFound::autowireMissing($type->getName(), $this->classToAutowire, $param->getName());
-        }
-        /** @var class-string */
-        $fqcn = $type->getName();
+        $fqcn = Autowire::getRequiredDependencyType($param, $this->classToAutowire);
         $this->dependencies[] = $fqcn;
         return sprintf(
             '$this->get(%s)',
-            var_export($type->getName(), true)
+            var_export($fqcn, true)
         );
     }
 }

--- a/src/DevContainer.php
+++ b/src/DevContainer.php
@@ -7,9 +7,7 @@ use Closure;
 use Exception;
 use Psr\Container\ContainerExceptionInterface;
 use ReflectionClass;
-use ReflectionNamedType;
 use Throwable;
-use TypeError;
 
 class DevContainer implements TypedContainerInterface
 {
@@ -169,15 +167,7 @@ class DevContainer implements TypedContainerInterface
                     return $param->getDefaultValue();
                 };
             } else {
-                if (!$param->hasType()) {
-                    throw new Exceptions\UntypedValue($param->getName(), $class);
-                }
-                $type = $param->getType();
-                assert($type instanceof ReflectionNamedType);
-                if ($type->isBuiltin()) {
-                    throw new Exceptions\UntypedValue($param->getName(), $class);
-                }
-                $name = $type->getName();
+                $name = Autowire::getRequiredDependencyType($param, $class);
                 if (!$this->has($name)) {
                     throw Exceptions\NotFound::autowireMissing($name, $class, $param->getName());
                 }

--- a/tests/AutowireTest.php
+++ b/tests/AutowireTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\Container;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers Firehed\Container\Autowire
+ */
+class AutowireTest extends TestCase
+{
+    public function testClassWithNoConstructorIsEligible(): void
+    {
+        self::assertTrue(Autowire::isEligible(Fixtures\NoConstructorFactory::class));
+    }
+
+    public function testClassWithObjectDependencyIsEligible(): void
+    {
+        self::assertTrue(Autowire::isEligible(Fixtures\SessionHandler::class));
+    }
+
+    public function testClassWithOptionalScalarIsEligible(): void
+    {
+        self::assertTrue(Autowire::isEligible(Fixtures\OptionalScalarParam::class));
+    }
+
+    public function testClassWithRequiredScalarIsNotEligible(): void
+    {
+        self::assertFalse(Autowire::isEligible(Fixtures\ConstructorScalar::class));
+    }
+
+    public function testClassWithUntypedParamIsNotEligible(): void
+    {
+        self::assertFalse(Autowire::isEligible(Fixtures\ConstructorUntyped::class));
+    }
+
+    public function testInterfaceIsNotEligible(): void
+    {
+        self::assertFalse(Autowire::isEligible(Fixtures\EmptyInterface::class));
+    }
+
+    public function testEnumIsNotEligible(): void
+    {
+        self::assertFalse(Autowire::isEligible(Fixtures\Environment::class));
+    }
+
+    public function testClassWithClosureParamIsNotEligible(): void
+    {
+        self::assertFalse(Autowire::isEligible(Fixtures\RequiresClosure::class));
+    }
+}

--- a/tests/AutowireTest.php
+++ b/tests/AutowireTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Firehed\Container;
 
 use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionParameter;
 
 /**
  * @covers Firehed\Container\Autowire
@@ -49,5 +51,78 @@ class AutowireTest extends TestCase
     public function testClassWithClosureParamIsNotEligible(): void
     {
         self::assertFalse(Autowire::isEligible(Fixtures\RequiresClosure::class));
+    }
+
+    public function testOptionalParameterIsAutowirable(): void
+    {
+        $param = $this->getConstructorParam(Fixtures\OptionalScalarParam::class, 'param');
+        self::assertTrue(Autowire::isParameterAutowirable($param));
+    }
+
+    public function testRequiredObjectParameterIsAutowirable(): void
+    {
+        $param = $this->getConstructorParam(Fixtures\SessionHandler::class, 'id');
+        self::assertTrue(Autowire::isParameterAutowirable($param));
+    }
+
+    public function testRequiredScalarParameterIsNotAutowirable(): void
+    {
+        $param = $this->getConstructorParam(Fixtures\ConstructorScalar::class, 'string');
+        self::assertFalse(Autowire::isParameterAutowirable($param));
+    }
+
+    public function testUntypedParameterIsNotAutowirable(): void
+    {
+        $param = $this->getConstructorParam(Fixtures\ConstructorUntyped::class, 'var');
+        self::assertFalse(Autowire::isParameterAutowirable($param));
+    }
+
+    public function testClosureParameterIsNotAutowirable(): void
+    {
+        $param = $this->getConstructorParam(Fixtures\RequiresClosure::class, 'callback');
+        self::assertFalse(Autowire::isParameterAutowirable($param));
+    }
+
+    public function testGetRequiredDependencyTypeReturnsTypeName(): void
+    {
+        $param = $this->getConstructorParam(Fixtures\SessionHandler::class, 'id');
+        $type = Autowire::getRequiredDependencyType($param, Fixtures\SessionHandler::class);
+        self::assertSame(\SessionIdInterface::class, $type);
+    }
+
+    public function testGetRequiredDependencyTypeThrowsForUntyped(): void
+    {
+        $param = $this->getConstructorParam(Fixtures\ConstructorUntyped::class, 'var');
+        $this->expectException(Exceptions\UntypedValue::class);
+        Autowire::getRequiredDependencyType($param, Fixtures\ConstructorUntyped::class);
+    }
+
+    public function testGetRequiredDependencyTypeThrowsForScalar(): void
+    {
+        $param = $this->getConstructorParam(Fixtures\ConstructorScalar::class, 'string');
+        $this->expectException(Exceptions\UntypedValue::class);
+        Autowire::getRequiredDependencyType($param, Fixtures\ConstructorScalar::class);
+    }
+
+    public function testGetRequiredDependencyTypeThrowsForClosure(): void
+    {
+        $param = $this->getConstructorParam(Fixtures\RequiresClosure::class, 'callback');
+        $this->expectException(Exceptions\UntypedValue::class);
+        Autowire::getRequiredDependencyType($param, Fixtures\RequiresClosure::class);
+    }
+
+    /**
+     * @param class-string $class
+     */
+    private function getConstructorParam(string $class, string $paramName): ReflectionParameter
+    {
+        $rc = new ReflectionClass($class);
+        $constructor = $rc->getMethod('__construct');
+        foreach ($constructor->getParameters() as $param) {
+            if ($param->getName() === $paramName) {
+                return $param;
+            }
+        }
+        throw new \RuntimeException("Parameter $paramName not found in $class");
     }
 }

--- a/tests/AutowireTest.php
+++ b/tests/AutowireTest.php
@@ -53,6 +53,21 @@ class AutowireTest extends TestCase
         self::assertFalse(Autowire::isEligible(Fixtures\RequiresClosure::class));
     }
 
+    public function testClassWithNoTypeHintIsNotEligible(): void
+    {
+        self::assertFalse(Autowire::isEligible(Fixtures\NoTypeHint::class));
+    }
+
+    public function testClassWithUnionTypeParamIsNotEligible(): void
+    {
+        self::assertFalse(Autowire::isEligible(Fixtures\UnionTypeParam::class));
+    }
+
+    public function testClassWithPrivateConstructorIsNotEligible(): void
+    {
+        self::assertFalse(Autowire::isEligible(Fixtures\PrivateConstructor::class));
+    }
+
     public function testOptionalParameterIsAutowirable(): void
     {
         $param = $this->getConstructorParam(Fixtures\OptionalScalarParam::class, 'param');
@@ -83,6 +98,18 @@ class AutowireTest extends TestCase
         self::assertFalse(Autowire::isParameterAutowirable($param));
     }
 
+    public function testNoTypeHintParameterIsNotAutowirable(): void
+    {
+        $param = $this->getConstructorParam(Fixtures\NoTypeHint::class, 'value');
+        self::assertFalse(Autowire::isParameterAutowirable($param));
+    }
+
+    public function testUnionTypeParameterIsNotAutowirable(): void
+    {
+        $param = $this->getConstructorParam(Fixtures\UnionTypeParam::class, 'id');
+        self::assertFalse(Autowire::isParameterAutowirable($param));
+    }
+
     public function testGetRequiredDependencyTypeReturnsTypeName(): void
     {
         $param = $this->getConstructorParam(Fixtures\SessionHandler::class, 'id');
@@ -109,6 +136,20 @@ class AutowireTest extends TestCase
         $param = $this->getConstructorParam(Fixtures\RequiresClosure::class, 'callback');
         $this->expectException(Exceptions\UntypedValue::class);
         Autowire::getRequiredDependencyType($param, Fixtures\RequiresClosure::class);
+    }
+
+    public function testGetRequiredDependencyTypeThrowsForNoTypeHint(): void
+    {
+        $param = $this->getConstructorParam(Fixtures\NoTypeHint::class, 'value');
+        $this->expectException(Exceptions\UntypedValue::class);
+        Autowire::getRequiredDependencyType($param, Fixtures\NoTypeHint::class);
+    }
+
+    public function testGetRequiredDependencyTypeThrowsForUnionType(): void
+    {
+        $param = $this->getConstructorParam(Fixtures\UnionTypeParam::class, 'id');
+        $this->expectException(Exceptions\UntypedValue::class);
+        Autowire::getRequiredDependencyType($param, Fixtures\UnionTypeParam::class);
     }
 
     /**

--- a/tests/Fixtures/NoTypeHint.php
+++ b/tests/Fixtures/NoTypeHint.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\Container\Fixtures;
+
+class NoTypeHint
+{
+    // phpcs:ignore Squiz.Commenting.FunctionComment.MissingParamName
+    /** @param mixed $value */
+    public function __construct(private $value)
+    {
+    }
+}

--- a/tests/Fixtures/PrivateConstructor.php
+++ b/tests/Fixtures/PrivateConstructor.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\Container\Fixtures;
+
+class PrivateConstructor
+{
+    private function __construct()
+    {
+    }
+
+    public static function create(): self
+    {
+        return new self();
+    }
+}

--- a/tests/Fixtures/RequiresClosure.php
+++ b/tests/Fixtures/RequiresClosure.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\Container\Fixtures;
+
+use Closure;
+
+class RequiresClosure
+{
+    public function __construct(private Closure $callback)
+    {
+    }
+}

--- a/tests/Fixtures/UnionTypeParam.php
+++ b/tests/Fixtures/UnionTypeParam.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\Container\Fixtures;
+
+class UnionTypeParam
+{
+    public function __construct(private SessionId|SessionIdManual $id)
+    {
+    }
+}


### PR DESCRIPTION
## Summary

- Extracts autowire eligibility logic into a reusable `Autowire` class
- Updates `DevContainer` and `AutowiredValue` to use the shared utility
- Filters out `Closure` and `Generator` types which cannot be autowired

## API

```php
// Check if a class can be fully autowired
Autowire::isEligible(MyService::class); // bool

// Check if a single parameter can be autowired  
Autowire::isParameterAutowirable($reflectionParam); // bool

// Get the type name for a required param (throws if not autowirable)
Autowire::getRequiredDependencyType($param, $declaringClass); // class-string
```

## Motivation

This prepares for #77 (config generator) which needs to check autowire eligibility. Rather than duplicate the logic, this extracts it into a shared utility that all autowiring code can use.

## Test plan

- [x] Existing tests pass (DevContainer, Compiler behavior unchanged)
- [x] New unit tests for Autowire utility

🤖 Generated with [Claude Code](https://claude.com/claude-code)