### PR TITLE
Check container for optional params before using default

### DIFF
--- a/src/Autowire.php
+++ b/src/Autowire.php
@@ -28,6 +28,51 @@ class Autowire
     ];
 
     /**
+     * Extract the resolvable type name from a parameter, if any.
+     *
+     * @return ?class-string The type name if resolvable, null otherwise
+     */
+    private static function getResolvableTypeName(ReflectionParameter $param): ?string
+    {
+        if (!$param->hasType()) {
+            return null;
+        }
+
+        $type = $param->getType();
+
+        // TODO: support ReflectionUnionType (#35), ReflectionIntersectionType (#36)?
+        if (!$type instanceof ReflectionNamedType) {
+            return null;
+        }
+
+        if ($type->isBuiltin()) {
+            return null;
+        }
+
+        $typeName = $type->getName();
+
+        if (in_array($typeName, self::NON_AUTOWIRABLE_TYPES, true)) {
+            return null;
+        }
+
+        /** @var class-string */
+        return $typeName;
+    }
+
+    /**
+     * Get the dependency type name for an optional parameter, if resolvable.
+     *
+     * Returns the type name if the parameter has an autowirable object type,
+     * null otherwise (scalar, untyped, union, etc).
+     *
+     * @return ?class-string
+     */
+    public static function getOptionalDependencyType(ReflectionParameter $param): ?string
+    {
+        return self::getResolvableTypeName($param);
+    }
+
+    /**
      * Get the dependency type name for a required parameter.
      *
      * This validates that the parameter can be autowired and returns
@@ -41,28 +86,10 @@ class Autowire
         ReflectionParameter $param,
         string $declaringClass,
     ): string {
-        if (!$param->hasType()) {
+        $typeName = self::getResolvableTypeName($param);
+        if ($typeName === null) {
             throw new Exceptions\UntypedValue($param->getName(), $declaringClass);
         }
-
-        $type = $param->getType();
-
-        // TODO: support ReflectionUnionType (#35), ReflectionIntersectionType (#36)?
-        if (!$type instanceof ReflectionNamedType) {
-            throw new Exceptions\UntypedValue($param->getName(), $declaringClass);
-        }
-
-        if ($type->isBuiltin()) {
-            throw new Exceptions\UntypedValue($param->getName(), $declaringClass);
-        }
-
-        $typeName = $type->getName();
-
-        if (in_array($typeName, self::NON_AUTOWIRABLE_TYPES, true)) {
-            throw new Exceptions\UntypedValue($param->getName(), $declaringClass);
-        }
-
-        /** @var class-string */
         return $typeName;
     }
 
@@ -75,29 +102,7 @@ class Autowire
      */
     public static function isParameterAutowirable(ReflectionParameter $param): bool
     {
-        if ($param->isOptional()) {
-            return true;
-        }
-
-        if (!$param->hasType()) {
-            return false;
-        }
-
-        $type = $param->getType();
-
-        if (!$type instanceof ReflectionNamedType) {
-            return false;
-        }
-
-        if ($type->isBuiltin()) {
-            return false;
-        }
-
-        if (in_array($type->getName(), self::NON_AUTOWIRABLE_TYPES, true)) {
-            return false;
-        }
-
-        return true;
+        return $param->isOptional() || self::getResolvableTypeName($param) !== null;
     }
 
     /**

--- a/src/Compiler/AutowiredValue.php
+++ b/src/Compiler/AutowiredValue.php
@@ -58,6 +58,17 @@ PHP;
     private function getDefaultValue(ReflectionParameter $param): string
     {
         if ($param->isOptional()) {
+            $typeName = Autowire::getOptionalDependencyType($param);
+            if ($typeName !== null) {
+                $exported = var_export($typeName, true);
+                $default = var_export($param->getDefaultValue(), true);
+                return sprintf(
+                    '$this->has(%s) ? $this->get(%s) : %s',
+                    $exported,
+                    $exported,
+                    $default,
+                );
+            }
             return var_export($param->getDefaultValue(), true);
         }
         $fqcn = Autowire::getRequiredDependencyType($param, $this->classToAutowire);

--- a/src/DevContainer.php
+++ b/src/DevContainer.php
@@ -163,9 +163,16 @@ class DevContainer implements TypedContainerInterface
         $needed = [];
         foreach ($params as $param) {
             if ($param->isOptional()) {
-                $needed[] = function () use ($param) {
-                    return $param->getDefaultValue();
-                };
+                $typeName = Autowire::getOptionalDependencyType($param);
+                if ($typeName !== null && $this->has($typeName)) {
+                    $needed[] = (function (TypedContainerInterface $c) use ($typeName) {
+                        return $c->get($typeName);
+                    })->bindTo(null);
+                } else {
+                    $needed[] = function () use ($param) {
+                        return $param->getDefaultValue();
+                    };
+                }
             } else {
                 $name = Autowire::getRequiredDependencyType($param, $class);
                 if (!$this->has($name)) {

--- a/tests/AutowireTest.php
+++ b/tests/AutowireTest.php
@@ -152,6 +152,20 @@ class AutowireTest extends TestCase
         Autowire::getRequiredDependencyType($param, Fixtures\UnionTypeParam::class);
     }
 
+    public function testGetOptionalDependencyTypeReturnsTypeForObjectParam(): void
+    {
+        $param = $this->getConstructorParam(Fixtures\OptionalObjectParam::class, 'sessionId');
+        $type = Autowire::getOptionalDependencyType($param);
+        self::assertSame(\SessionIdInterface::class, $type);
+    }
+
+    public function testGetOptionalDependencyTypeReturnsNullForScalarParam(): void
+    {
+        $param = $this->getConstructorParam(Fixtures\OptionalScalarParam::class, 'param');
+        $type = Autowire::getOptionalDependencyType($param);
+        self::assertNull($type);
+    }
+
     /**
      * @param class-string $class
      */

--- a/tests/ContainerBuilderTestTrait.php
+++ b/tests/ContainerBuilderTestTrait.php
@@ -319,6 +319,28 @@ trait ContainerBuilderTestTrait
         $this->assertNull($osp->getParam());
     }
 
+    /**
+     * OptionalObjectParam::class => autowire()
+     * SessionIdInterface::class => Fixtures\SessionId::class
+     *
+     * When the container has an entry for an optional parameter's type,
+     * it should be injected rather than using the default value.
+     */
+    public function testOptionalObjectParamUsesContainerEntryWhenAvailable(): void
+    {
+        $container = $this->getContainer();
+        $oop = $this->assertGetSingleton(
+            $container,
+            Fixtures\OptionalObjectParam::class
+        );
+        assert($oop instanceof Fixtures\OptionalObjectParam);
+        // SessionIdInterface is registered, so it should be injected
+        $this->assertInstanceOf(
+            Fixtures\SessionId::class,
+            $oop->getSessionId(),
+        );
+    }
+
     public function testHasWithMissingKeyReturnsFalse(): void
     {
         $container = $this->getContainer();

--- a/tests/Fixtures/OptionalObjectParam.php
+++ b/tests/Fixtures/OptionalObjectParam.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\Container\Fixtures;
+
+use SessionIdInterface;
+
+class OptionalObjectParam
+{
+    public function __construct(
+        private ?SessionIdInterface $sessionId = null,
+    ) {
+    }
+
+    public function getSessionId(): ?SessionIdInterface
+    {
+        return $this->sessionId;
+    }
+}

--- a/tests/ValidDefinitions/ScalarParams.php
+++ b/tests/ValidDefinitions/ScalarParams.php
@@ -7,4 +7,5 @@ use Firehed\Container\Fixtures;
 return [
     Fixtures\DefaultScalarParam::class => autowire(),
     Fixtures\OptionalScalarParam::class => autowire(),
+    Fixtures\OptionalObjectParam::class => autowire(),
 ];


### PR DESCRIPTION
## Summary

- Fixes #81
- When autowiring, optional constructor parameters now check the container for a matching type before falling back to the default value
- Matches behavior of general expectations, as well as many other DI containers (Symfony, Laravel, PHP-DI)

## Changes

- Extract shared type resolution logic in `Autowire` class
- Add `getOptionalDependencyType()` for checking optional param types
- Update `DevContainer` to check container before using default
- Update `AutowiredValue` (compiler) to generate runtime `has()` checks

## Test plan

- [x] Added test for optional object param with container entry
- [x] Existing tests pass (optional scalar params still use defaults)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)