### PR TITLE
Extract Autowire::instantiate() for reuse

### DIFF
--- a/src/Autowire.php
+++ b/src/Autowire.php
@@ -18,6 +18,46 @@ use ReflectionParameter;
 class Autowire
 {
     /**
+     * Instantiate a class by resolving its constructor dependencies from the container.
+     *
+     * @throws Exceptions\AmbiguousMapping if the class does not exist
+     */
+    public static function instantiate(string $class, TypedContainerInterface $container): object
+    {
+        if (!class_exists($class)) {
+            throw new Exceptions\AmbiguousMapping($class);
+        }
+        $rc = new ReflectionClass($class);
+
+        if (!$rc->hasMethod('__construct')) {
+            return new $class();
+        }
+
+        $construct = $rc->getMethod('__construct');
+        $params = $construct->getParameters();
+        $args = [];
+
+        foreach ($params as $param) {
+            if ($param->isOptional()) {
+                $typeName = self::getOptionalDependencyType($param);
+                if ($typeName !== null && $container->has($typeName)) {
+                    $args[] = $container->get($typeName);
+                } else {
+                    $args[] = $param->getDefaultValue();
+                }
+            } else {
+                $name = self::getRequiredDependencyType($param, $class);
+                if (!$container->has($name)) {
+                    throw Exceptions\NotFound::autowireMissing($name, $class, $param->getName());
+                }
+                $args[] = $container->get($name);
+            }
+        }
+
+        return new $class(...$args);
+    }
+
+    /**
      * Types that cannot meaningfully be autowired from a container.
      * These are internal PHP types that are not instantiable or are
      * created through special language constructs.

--- a/src/DevContainer.php
+++ b/src/DevContainer.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 namespace Firehed\Container;
 
 use Closure;
-use Exception;
 use Psr\Container\ContainerExceptionInterface;
-use ReflectionClass;
 use Throwable;
 
 class DevContainer implements TypedContainerInterface
@@ -78,12 +76,12 @@ class DevContainer implements TypedContainerInterface
         if ($def instanceof AutowireInterface) {
             $classToAutowire = $def->getWiredClass() ?? $id;
             $value = $this->autowire($classToAutowire);
-        } else {
-            $value = $def;
+            $this->evaluated[$id] = $value;
+            return $value;
         }
 
-        if ($value instanceof Closure) {
-            $rebound = $value->bindTo(null);
+        if ($def instanceof Closure) {
+            $rebound = $def->bindTo(null);
             assert($rebound !== null);
             $evaluated = $rebound($this);
             $this->evaluated[$id] = $evaluated;
@@ -91,67 +89,18 @@ class DevContainer implements TypedContainerInterface
             return $evaluated;
         }
 
-        if ($value instanceof FactoryInterface) {
-            if ($value->hasDefinition()) {
-                return $value->getDefinition()($this);
+        if ($def instanceof FactoryInterface) {
+            if ($def->hasDefinition()) {
+                return $def->getDefinition()($this);
             }
-            return $this->autowire($id)($this);
+            return $this->autowire($id);
         }
 
-        return $value;
+        return $def;
     }
 
-    /**
-     * Returns a closure that takes the container as its only argument and
-     * returns the instantiated object
-     */
-    private function autowire(string $class): Closure
+    private function autowire(string $class): object
     {
-        if (!class_exists($class)) {
-            throw new Exceptions\AmbiguousMapping($class);
-        }
-        $rc = new ReflectionClass($class);
-
-        if (!$rc->hasMethod('__construct')) {
-            return (function () use ($class) {
-                return new $class();
-            })->bindTo(null);
-        }
-
-        $construct = $rc->getMethod('__construct');
-        if (!$construct->isPublic()) {
-            throw new \Exception('non public construct');
-        }
-
-        $params = $construct->getParameters();
-        $needed = [];
-        foreach ($params as $param) {
-            if ($param->isOptional()) {
-                $typeName = Autowire::getOptionalDependencyType($param);
-                if ($typeName !== null && $this->has($typeName)) {
-                    $needed[] = (function (TypedContainerInterface $c) use ($typeName) {
-                        return $c->get($typeName);
-                    })->bindTo(null);
-                } else {
-                    $needed[] = function () use ($param) {
-                        return $param->getDefaultValue();
-                    };
-                }
-            } else {
-                $name = Autowire::getRequiredDependencyType($param, $class);
-                if (!$this->has($name)) {
-                    throw Exceptions\NotFound::autowireMissing($name, $class, $param->getName());
-                }
-                $needed[] = (function (TypedContainerInterface $c) use ($name) {
-                    return $c->get($name);
-                })->bindTo(null);
-            }
-        }
-        return (function (TypedContainerInterface $container) use ($class, $needed) {
-            $args = array_map(function ($arg) use ($container) {
-                return $arg($container);
-            }, $needed);
-            return new $class(...$args);
-        })->bindTo(null);
+        return Autowire::instantiate($class, $this);
     }
 }

--- a/tests/BuilderTest.php
+++ b/tests/BuilderTest.php
@@ -7,6 +7,7 @@ namespace Firehed\Container;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
+#[CoversClass(Autowire::class)]
 #[CoversClass(Builder::class)]
 #[CoversClass(DevContainer::class)]
 class BuilderTest extends TestCase


### PR DESCRIPTION
## Summary

Extracts runtime autowiring logic from `DevContainer::autowire()` to `Autowire::instantiate()`.

This is the foundation for #94 and #95, which will use this method and eventually allow `DevContainer::autowire()` to be deleted entirely.

**Stack:** 1 of 3
- **→ This PR**
- #94: Factory implements DefinitionInterface
- #95: AutowiredClass implements DefinitionInterface

🤖 Generated with [Claude Code](https://claude.ai/code)