### PR TITLE
Convert FactoryInterface to DefinitionInterface

### DIFF
--- a/src/Autowire.php
+++ b/src/Autowire.php
@@ -18,6 +18,46 @@ use ReflectionParameter;
 class Autowire
 {
     /**
+     * Instantiate a class by resolving its constructor dependencies from the container.
+     *
+     * @throws Exceptions\AmbiguousMapping if the class does not exist
+     */
+    public static function instantiate(string $class, TypedContainerInterface $container): object
+    {
+        if (!class_exists($class)) {
+            throw new Exceptions\AmbiguousMapping($class);
+        }
+        $rc = new ReflectionClass($class);
+
+        if (!$rc->hasMethod('__construct')) {
+            return new $class();
+        }
+
+        $construct = $rc->getMethod('__construct');
+        $params = $construct->getParameters();
+        $args = [];
+
+        foreach ($params as $param) {
+            if ($param->isOptional()) {
+                $typeName = self::getOptionalDependencyType($param);
+                if ($typeName !== null && $container->has($typeName)) {
+                    $args[] = $container->get($typeName);
+                } else {
+                    $args[] = $param->getDefaultValue();
+                }
+            } else {
+                $name = self::getRequiredDependencyType($param, $class);
+                if (!$container->has($name)) {
+                    throw Exceptions\NotFound::autowireMissing($name, $class, $param->getName());
+                }
+                $args[] = $container->get($name);
+            }
+        }
+
+        return new $class(...$args);
+    }
+
+    /**
      * Types that cannot meaningfully be autowired from a container.
      * These are internal PHP types that are not instantiable or are
      * created through special language constructs.

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -41,6 +41,14 @@ class Builder implements BuilderInterface
                 $key = $value;
                 $value = autowire();
             }
+            // Finalize factory definitions that need the key as the class
+            if ($value instanceof FactoryInterface && !$value->hasDefinition()) {
+                if (!class_exists($key)) {
+                    $this->errors[] = new Exceptions\AmbiguousMapping($key);
+                    continue;
+                }
+                $value = $value->withClass($key);
+            }
             // This assumes that any array key which is a FQCN for an interface
             // is an interface-to-implementation wiring. This means that simple
             // string value MUST NOT be keyed to an interface name

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -104,24 +104,19 @@ class Compiler implements BuilderInterface
     private function add(string $key, $value): void
     {
         $this->logger->debug('Adding definition for "{key}"', ['key' => $key]);
+        // Finalize factory definitions that need the key as the class
+        if ($value instanceof FactoryInterface && !$value->hasDefinition()) {
+            if (!class_exists($key)) {
+                $this->errors[] = new Exceptions\AmbiguousMapping($key);
+                return;
+            }
+            $value = $value->withClass($key);
+        }
         if ($value instanceof DefinitionInterface) {
             if (!$value->isCacheable()) {
                 $this->factories[$key] = true;
             }
             $this->definitions[$key] = $value;
-        } elseif ($value instanceof FactoryInterface) {
-            $this->factories[$key] = true;
-            if ($value->hasDefinition()) {
-                // Something::class => factory(fn ($container) => new Something(...))
-                $this->definitions[$key] = new Compiler\ClosureValue($value->getDefinition());
-            } else {
-                if (class_exists($key)) {
-                    // Something::class => factory()
-                    $this->definitions[$key] = new Compiler\AutowiredValue($key);
-                } else {
-                    $this->errors[] = new Exceptions\AmbiguousMapping($key);
-                }
-            }
         } elseif ($value instanceof AutowireInterface) {
             // someName => autowire(...)
             // someName,

--- a/src/DevContainer.php
+++ b/src/DevContainer.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 namespace Firehed\Container;
 
 use Closure;
-use Exception;
 use Psr\Container\ContainerExceptionInterface;
-use ReflectionClass;
 use Throwable;
 
 class DevContainer implements TypedContainerInterface
@@ -78,12 +76,12 @@ class DevContainer implements TypedContainerInterface
         if ($def instanceof AutowireInterface) {
             $classToAutowire = $def->getWiredClass() ?? $id;
             $value = $this->autowire($classToAutowire);
-        } else {
-            $value = $def;
+            $this->evaluated[$id] = $value;
+            return $value;
         }
 
-        if ($value instanceof Closure) {
-            $rebound = $value->bindTo(null);
+        if ($def instanceof Closure) {
+            $rebound = $def->bindTo(null);
             assert($rebound !== null);
             $evaluated = $rebound($this);
             $this->evaluated[$id] = $evaluated;
@@ -91,67 +89,18 @@ class DevContainer implements TypedContainerInterface
             return $evaluated;
         }
 
-        if ($value instanceof FactoryInterface) {
-            if ($value->hasDefinition()) {
-                return $value->getDefinition()($this);
+        if ($def instanceof FactoryInterface) {
+            if ($def->hasDefinition()) {
+                return $def->getDefinition()($this);
             }
-            return $this->autowire($id)($this);
+            return $this->autowire($id);
         }
 
-        return $value;
+        return $def;
     }
 
-    /**
-     * Returns a closure that takes the container as its only argument and
-     * returns the instantiated object
-     */
-    private function autowire(string $class): Closure
+    private function autowire(string $class): object
     {
-        if (!class_exists($class)) {
-            throw new Exceptions\AmbiguousMapping($class);
-        }
-        $rc = new ReflectionClass($class);
-
-        if (!$rc->hasMethod('__construct')) {
-            return (function () use ($class) {
-                return new $class();
-            })->bindTo(null);
-        }
-
-        $construct = $rc->getMethod('__construct');
-        if (!$construct->isPublic()) {
-            throw new \Exception('non public construct');
-        }
-
-        $params = $construct->getParameters();
-        $needed = [];
-        foreach ($params as $param) {
-            if ($param->isOptional()) {
-                $typeName = Autowire::getOptionalDependencyType($param);
-                if ($typeName !== null && $this->has($typeName)) {
-                    $needed[] = (function (TypedContainerInterface $c) use ($typeName) {
-                        return $c->get($typeName);
-                    })->bindTo(null);
-                } else {
-                    $needed[] = function () use ($param) {
-                        return $param->getDefaultValue();
-                    };
-                }
-            } else {
-                $name = Autowire::getRequiredDependencyType($param, $class);
-                if (!$this->has($name)) {
-                    throw Exceptions\NotFound::autowireMissing($name, $class, $param->getName());
-                }
-                $needed[] = (function (TypedContainerInterface $c) use ($name) {
-                    return $c->get($name);
-                })->bindTo(null);
-            }
-        }
-        return (function (TypedContainerInterface $container) use ($class, $needed) {
-            $args = array_map(function ($arg) use ($container) {
-                return $arg($container);
-            }, $needed);
-            return new $class(...$args);
-        })->bindTo(null);
+        return Autowire::instantiate($class, $this);
     }
 }

--- a/src/DevContainer.php
+++ b/src/DevContainer.php
@@ -89,13 +89,6 @@ class DevContainer implements TypedContainerInterface
             return $evaluated;
         }
 
-        if ($def instanceof FactoryInterface) {
-            if ($def->hasDefinition()) {
-                return $def->getDefinition()($this);
-            }
-            return $this->autowire($id);
-        }
-
         return $def;
     }
 

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -22,12 +22,6 @@ class Factory implements FactoryInterface, DefinitionInterface
         return $this->def !== null;
     }
 
-    public function getDefinition(): Closure
-    {
-        assert($this->def !== null);
-        return $this->def;
-    }
-
     /**
      * Sets the class to autowire when there's no closure definition.
      * Used by builders when factory() is called without arguments.

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -1,12 +1,18 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Firehed\Container;
 
 use Closure;
 
-class Factory implements FactoryInterface
+class Factory implements FactoryInterface, DefinitionInterface
 {
+    /** @var ?class-string */
+    private ?string $classToAutowire = null;
+
+    private Compiler\CodeGeneratorInterface $codeGenerator;
+
     public function __construct(private ?Closure $def)
     {
     }
@@ -20,5 +26,52 @@ class Factory implements FactoryInterface
     {
         assert($this->def !== null);
         return $this->def;
+    }
+
+    /**
+     * Sets the class to autowire when there's no closure definition.
+     * Used by builders when factory() is called without arguments.
+     *
+     * @param class-string $class
+     */
+    public function withClass(string $class): self
+    {
+        $new = clone $this;
+        $new->classToAutowire = $class;
+        return $new;
+    }
+
+    public function isCacheable(): bool
+    {
+        return false;
+    }
+
+    public function resolve(TypedContainerInterface $container, EnvReader $envReader): mixed
+    {
+        if ($this->def !== null) {
+            $rebound = $this->def->bindTo(null);
+            assert($rebound !== null);
+            return $rebound($container);
+        }
+
+        assert($this->classToAutowire !== null, 'Class must be set for factory without definition');
+        return Autowire::instantiate($this->classToAutowire, $container);
+    }
+
+    public function generateCode(): string
+    {
+        if ($this->def !== null) {
+            $this->codeGenerator = new Compiler\ClosureValue($this->def);
+        } else {
+            assert($this->classToAutowire !== null, 'Class must be set for factory without definition');
+            $this->codeGenerator = new Compiler\AutowiredValue($this->classToAutowire);
+        }
+        return $this->codeGenerator->generateCode();
+    }
+
+    /** @return class-string[] */
+    public function getDependencies(): array
+    {
+        return $this->codeGenerator->getDependencies();
     }
 }

--- a/src/FactoryInterface.php
+++ b/src/FactoryInterface.php
@@ -9,4 +9,11 @@ interface FactoryInterface
 {
     public function getDefinition(): Closure;
     public function hasDefinition(): bool;
+
+    /**
+     * Sets the class to autowire when there's no closure definition.
+     *
+     * @param class-string $class
+     */
+    public function withClass(string $class): self;
 }

--- a/src/FactoryInterface.php
+++ b/src/FactoryInterface.php
@@ -3,11 +3,8 @@ declare(strict_types=1);
 
 namespace Firehed\Container;
 
-use Closure;
-
 interface FactoryInterface
 {
-    public function getDefinition(): Closure;
     public function hasDefinition(): bool;
 
     /**

--- a/tests/BuilderTest.php
+++ b/tests/BuilderTest.php
@@ -10,6 +10,7 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(Autowire::class)]
 #[CoversClass(Builder::class)]
 #[CoversClass(DevContainer::class)]
+#[CoversClass(Factory::class)]
 class BuilderTest extends TestCase
 {
     use ContainerBuilderTestTrait;

--- a/tests/CompilerTest.php
+++ b/tests/CompilerTest.php
@@ -17,6 +17,7 @@ use Psr\Log\AbstractLogger;
 #[CoversClass(Compiler\ProxyValue::class)]
 #[CoversClass(EnvironmentVariable::class)]
 #[CoversClass(Exceptions\IncorrectlyTypedValue::class)]
+#[CoversClass(Factory::class)]
 class CompilerTest extends TestCase
 {
     use ContainerBuilderTestTrait;


### PR DESCRIPTION
## Summary

- `Factory` now implements `DefinitionInterface`
- Added `withClass()` to `FactoryInterface` for finalizing bare `factory()` calls
- Removed special-cased `instanceof FactoryInterface` handling from `Compiler` and `DevContainer` (mostly... there are still some "finalizing" tricks that need to happen, follow up on that later)

**Stack:** 2 of 3
- #98: Extract Autowire::instantiate()
- **→ This PR**
- #95: AutowiredClass implements DefinitionInterface

Fixes #94

🤖 Generated with [Claude Code](https://claude.ai/code)