### PR TITLE
Add `addDirectory` to `BuilderInterface`

### DIFF
--- a/src/AutoDetect.php
+++ b/src/AutoDetect.php
@@ -38,10 +38,6 @@ final class AutoDetect
      */
     public static function from(string $directory, array $envNames = self::ENVIRONMENT_NAMES): TypedContainerInterface
     {
-        if ($directory === '') {
-            throw new InvalidArgumentException('Directory is empty. Did you mean "."?');
-        }
-
         $reader = new EnvReader($_ENV);
         $env = null;
         foreach ($envNames as $envName) {

--- a/src/AutoDetect.php
+++ b/src/AutoDetect.php
@@ -33,6 +33,7 @@ final class AutoDetect
      * the dynamic or compiled config builder based on whether a development
      * environment is detected.
      *
+     * @param non-empty-literal-string $directory
      * @param non-empty-array<literal-string> $envNames
      */
     public static function from(string $directory, array $envNames = self::ENVIRONMENT_NAMES): TypedContainerInterface
@@ -72,6 +73,7 @@ final class AutoDetect
      * container to manage object instances, it's possible to run into subtle
      * issues if there are multiple instances of the container itself
      *
+     * @param non-empty-literal-string $directory
      * @param non-empty-array<literal-string> $envNames
      */
     public static function instance(

--- a/src/AutoDetect.php
+++ b/src/AutoDetect.php
@@ -63,18 +63,7 @@ final class AutoDetect
         } else {
             $builder = new Compiler(self::$compiledOutputPath);
         }
-
-        $files = glob($directory . '/*.php');
-        if ($files === false) {
-            throw new RuntimeException('Could not read config directory');
-        }
-        if ($files === []) {
-            throw new UnexpectedValueException('No config files found in the specified directory');
-        }
-        foreach ($files as $file) {
-            $builder->addFile($file);
-        }
-
+        $builder->addDirectory($directory);
         return $builder->build();
     }
 

--- a/src/BuilderInterface.php
+++ b/src/BuilderInterface.php
@@ -8,6 +8,11 @@ interface BuilderInterface
 {
     /**
      * Add all `.php` files in the directory to the builder. Not recursive.
+     *
+     * @param non-empty-literal-string $directory The path to include from. This
+     * may be relative or absolute but should be a literal value. Setting this
+     * from a dynamic source is NOT RECOMMENDED, and could pose a security risk
+     * if user-controlled.
      */
     public function addDirectory(string $directory): void;
 

--- a/src/BuilderInterface.php
+++ b/src/BuilderInterface.php
@@ -1,10 +1,13 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Firehed\Container;
 
 interface BuilderInterface
 {
+    public function addDirectory(string $directory): void;
+
     public function addFile(string $file): void;
 
     public function build(): TypedContainerInterface;

--- a/src/BuilderInterface.php
+++ b/src/BuilderInterface.php
@@ -6,6 +6,9 @@ namespace Firehed\Container;
 
 interface BuilderInterface
 {
+    /**
+     * Add all `.php` files in the directory to the builder. Not recursive.
+     */
     public function addDirectory(string $directory): void;
 
     public function addFile(string $file): void;

--- a/src/BuilderTrait.php
+++ b/src/BuilderTrait.php
@@ -5,9 +5,25 @@ declare(strict_types=1);
 namespace Firehed\Container;
 
 use Closure;
+use RuntimeException;
+use UnexpectedValueException;
 
 trait BuilderTrait
 {
+    public function addDirectory(string $directory): void
+    {
+        $files = glob($directory . '/*.php');
+        if ($files === false) {
+            throw new RuntimeException('Could not read config directory');
+        }
+        if ($files === []) {
+            throw new UnexpectedValueException('No config files found in the specified directory');
+        }
+        foreach ($files as $file) {
+            $this->addFile($file);
+        }
+    }
+
     /**
      * Given the contents of a standard container config file, pre-process some
      * of the shorthand/"magical" definitions into actual DefinitionInterface

--- a/src/BuilderTrait.php
+++ b/src/BuilderTrait.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Firehed\Container;
 
 use Closure;
+use InvalidArgumentException;
 use RuntimeException;
 use UnexpectedValueException;
 
@@ -12,6 +13,9 @@ trait BuilderTrait
 {
     public function addDirectory(string $directory): void
     {
+        if ($directory === '') {
+            throw new InvalidArgumentException('Directory must not be empty. Did you mean `.`?');
+        }
         $files = glob($directory . '/*.php');
         if ($files === false) {
             throw new RuntimeException('Could not read config directory');

--- a/tests/AutoDetectTest.php
+++ b/tests/AutoDetectTest.php
@@ -25,8 +25,9 @@ class AutoDetectTest extends TestCase
 
     public function testEmptyDirectoryIsError(): void
     {
+        $_ENV['ENV'] = 'development';
         self::expectException(LogicException::class);
-        self::expectExceptionMessage('Directory is empty');
+        self::expectExceptionMessage('Directory must not be empty');
         // @phpstan-ignore argument.type (Explicitly testing the guard)
         AutoDetect::from('');
     }

--- a/tests/AutoDetectTest.php
+++ b/tests/AutoDetectTest.php
@@ -27,6 +27,7 @@ class AutoDetectTest extends TestCase
     {
         self::expectException(LogicException::class);
         self::expectExceptionMessage('Directory is empty');
+        // @phpstan-ignore argument.type (Explicitly testing the guard)
         AutoDetect::from('');
     }
 

--- a/tests/ContainerBuilderTestTrait.php
+++ b/tests/ContainerBuilderTestTrait.php
@@ -381,6 +381,66 @@ trait ContainerBuilderTestTrait
         self::assertStringContainsString('string_literal', $output);
     }
 
+    public function testAddDirectoryLoadsAllPhpFiles(): void
+    {
+        $builder = $this->getBuilder();
+        // OldPhpSafe/one.php defines 'a' => 'b'
+        $builder->addDirectory(__DIR__ . '/ValidDefinitions/OldPhpSafe');
+        $container = $builder->build();
+        $this->assertTrue(
+            $container->has('a'),
+            'Container should have entries from directory',
+        );
+        $this->assertSame('b', $container->get('a'));
+    }
+
+    public function testAddDirectoryThrowsOnEmptyString(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Directory is empty');
+        $builder = $this->getBuilder();
+        $builder->addDirectory('');
+    }
+
+    public function testAddDirectoryThrowsWhenNoPhpFilesFound(): void
+    {
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage('No config files');
+        $builder = $this->getBuilder();
+        $builder->addDirectory(__DIR__ . '/../.github');
+    }
+
+    public function testAddDirectoryIsNonRecursive(): void
+    {
+        $builder = $this->getBuilder();
+        $builder->addDirectory(__DIR__ . '/ValidDefinitions');
+        $container = $builder->build();
+        // Files in ValidDefinitions/OldPhpSafe should not be loaded
+        // OldPhpSafe/one.php defines 'a' => 'b'
+        $this->assertFalse(
+            $container->has('a'),
+            'Subdirectory files should not be loaded by addDirectory',
+        );
+    }
+
+    public function testMultipleAddDirectoryCalls(): void
+    {
+        $builder = $this->getBuilder();
+        // OldPhpSafe/one.php defines 'a' => 'b'
+        $builder->addDirectory(__DIR__ . '/ValidDefinitions/OldPhpSafe');
+        // ValidDefinitions/ defines 'string_literal' and Fixtures\SessionId::class
+        $builder->addDirectory(__DIR__ . '/ValidDefinitions');
+        $container = $builder->build();
+        $this->assertTrue(
+            $container->has('a'),
+            'Container should have entries from first directory',
+        );
+        $this->assertTrue(
+            $container->has('string_literal'),
+            'Container should have entries from second directory',
+        );
+    }
+
     // Data Providers
 
     /** @return mixed[][] */

--- a/tests/ContainerBuilderTestTrait.php
+++ b/tests/ContainerBuilderTestTrait.php
@@ -8,11 +8,13 @@ use DateTime;
 use DateTimeImmutable;
 use DateTimeInterface;
 use Firehed\Container\Exceptions\IncorrectlyTypedValue;
+use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Psr\Container\ContainerInterface;
 use Psr\Container\NotFoundExceptionInterface;
 use SessionHandlerInterface;
 use SessionIdInterface;
+use UnexpectedValueException;
 
 /**
  * This is a test trait to help ensure all processes end up with the same
@@ -397,8 +399,8 @@ trait ContainerBuilderTestTrait
     public function testAddDirectoryThrowsOnEmptyString(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Directory is empty');
         $builder = $this->getBuilder();
+        // @phpstan-ignore argument.type (Explicitly testing the guard)
         $builder->addDirectory('');
     }
 


### PR DESCRIPTION
This does what the title implies: builders can now take a directory, and they will add all of the php files contained within, saving callers from doing this common loop themselves. It is not recursive.

The logic was already in AutoDetect, so it's been updated to leverage this new API.